### PR TITLE
feat: add seed data

### DIFF
--- a/.github/workflows/run-terraform.yml
+++ b/.github/workflows/run-terraform.yml
@@ -69,7 +69,8 @@ jobs:
 
       - name: "Run tests"
         run: |-
-          echo "::notice title=This is a placeholder::In the future, this job would run automated tests, e.g. using Postman, etc."
+          curl --fail http://localhost/bob/health/api/check/readiness
+          curl --fail http://localhost/alice/health/api/check/readiness
 
       - name: "Destroy the KinD cluster"
         run: >-

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -49,6 +49,41 @@ potato, it'll take even longer. Just get a coffee. Eventually, it should look si
 
 ![img.png](assets/img.png)
 
+### Inspect terraform output
+
+After the `terraform` command has successfully completed, it will output a few configuration and setup values
+that we will need in later steps. Please note that most values will be different on your local system.
+
+```shell
+Outputs:
+
+alice-urls = {
+  "health" = "http://localhost/alice/health"
+  "management" = "http://localhost/alice/management/v2"
+}
+bob-node-ip = "10.96.248.22"
+bob-urls = {
+  "health" = "http://localhost/bob/health"
+  "management" = "http://localhost/bob/management/v2"
+}
+connector1-aeskey = "R3BDWGF4SWFYZigmVj0oIQ=="
+connector1-client-secret = "W3s1OikqRkxCbltfNDBmRg=="
+connector2-aeskey = "JHJISjZAS0tSKlNYajJTZA=="
+connector2-client-secret = "enFFUlkwQyZiJSRLQSohYg=="
+keycloak-database-credentials = {
+  "database" = "miw"
+  "password" = "Tn*iwPEuCgO@d==R"
+  "user" = "miw_user"
+}
+keycloak-ip = "10.96.103.80"
+miw-database-pwd = {
+  "database" = "keycloak"
+  "password" = "W:z)*mnHdy(DTV?+"
+  "user" = "keycloak_user"
+}
+postgres-url = "jdbc:postgresql://10.96.195.240:5432/"
+```
+
 ### Inspect the databases
 
 Please be aware, that all services and applications that were deployed in the previous step, are **not** accessible from
@@ -70,9 +105,8 @@ and `password=postgres`:
 
 Every service in the cluster has their own database, but for the sake of simplicity, they are hosted in one Postgres
 server. We will show in [later sections](#8-improving-the-setup), how the databases can be segregated out. Feel free to
-inspect all the databases
-and tables, but there is not much data in there yet. Particularly the connector databases will be empty. We will fill
-them in the subsequent steps.
+inspect all the databases and tables, but there is not much data in there yet. There is just a few automatically seeded
+assets, policies and contract definitions.
 
 ### Verify your local installation
 
@@ -102,6 +136,73 @@ which should return something similar to this, the important part being the `isS
   "isSystemHealthy": true
 }
 ```
+
+Once we've established the basic readiness of our connectors, we can move on to inspect a few data items:
+
+```shell
+curl -X POST http://localhost/bob/management/v3/assets/request -H "x-api-key: password" -H "content-type: application/json" | jq
+```
+
+this queries the `/assets` endpoint returning the entire list of assets that `bob` currently maintains. You should see
+something like
+
+```json
+[
+  {
+    "@id": "1",
+    "@type": "edc:Asset",
+    "edc:properties": {
+      "edc:description": "Product EDC Demo Asset 1",
+      "edc:id": "1"
+    },
+    "edc:dataAddress": {
+      "@type": "edc:DataAddress",
+      "edc:type": "HttpData",
+      "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos"
+    },
+    "@context": {
+      "dct": "https://purl.org/dc/terms/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "dcat": "https://www.w3.org/ns/dcat/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "dspace": "https://w3id.org/dspace/v0.8/"
+    }
+  },
+  {
+    "@id": "2",
+    "@type": "edc:Asset",
+    "edc:properties": {
+      "edc:description": "Product EDC Demo Asset 2",
+      "edc:id": "2"
+    },
+    "edc:dataAddress": {
+      "@type": "edc:DataAddress",
+      "edc:type": "HttpData",
+      "edc:baseUrl": "https://jsonplaceholder.typicode.com/todos"
+    },
+    "@context": {
+      "dct": "https://purl.org/dc/terms/",
+      "tx": "https://w3id.org/tractusx/v0.0.1/ns/",
+      "edc": "https://w3id.org/edc/v0.0.1/ns/",
+      "dcat": "https://www.w3.org/ns/dcat/",
+      "odrl": "http://www.w3.org/ns/odrl/2/",
+      "dspace": "https://w3id.org/dspace/v0.8/"
+    }
+  }
+]
+```
+
+Note: the same thing can be done to inspect policies and contract definitions. The respective `curl` commands are:
+
+```shell
+# policies:
+curl -X POST http://localhost/bob/management/v2/policydefinitions/request -H "x-api-key: password" -H "content-type: application/json" | jq
+# contract defs:
+curl -X POST http://localhost/bob/management/v2/contractdefinitions/request -H "x-api-key: password" -H "content-type: application/json" | jq
+```
+
+Alternatively, please check out the [Postman collections here](./postman)
 
 ## 3. Add some data
 

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -32,15 +32,20 @@ For the most bare-bones installation of the dataspace, execute the following com
 
 ```shell
 kind create cluster -n mxd
+# the next step is specific to KinD and will be different for other Kubernetes runtimes!
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
 cd <path/of/mxd>
 terraform init
 terraform apply
 # type "yes" and press enter when prompted to do so 
 ```
 
+Notice that the `kubectl apply` command deploys a Kubernetes Ingress Controller to the cluster and is required to reach
+our applications from outside the cluster. Specifically, it deploys an NGINX ingress controller. Notice also, that the
+command is *specific to KinD* and will likely not work on other Kubernetes runtimes or with other ingress controllers!
+
 Wait. Then wait some more. It will take a couple of minutes until all services are booted up. If your machine is a
-potato,
-it'll take even longer. Just get a coffee. Eventually, it should look similar to this:
+potato, it'll take even longer. Just get a coffee. Eventually, it should look similar to this:
 
 ![img.png](assets/img.png)
 
@@ -69,15 +74,17 @@ inspect all the databases
 and tables, but there is not much data in there yet. Particularly the connector databases will be empty. We will fill
 them in the subsequent steps.
 
-
 ### Verify your local installation
 
 In order to check that the connectors were deployed successfully, please execute the following commands in a shell:
+
 ```shell
 curl -X GET http://localhost/bob/health/api/check/liveness
 curl -X GET http://localhost/alice/health/api/check/liveness
 ```
-which should return something similar to this, the important part being the `isSystemHealthy: true` bit: 
+
+which should return something similar to this, the important part being the `isSystemHealthy: true` bit:
+
 ```json
 {
   "componentResults": [
@@ -101,7 +108,6 @@ which should return something similar to this, the important part being the `isS
 In this step we will focus on inserting data into our participant Alice using
 the [Management API](https://app.swaggerhub.com/apis/eclipse-edc-bot/management-api/0.1.4-SNAPSHOT). We will use plain
 CLI tools (`curl`) for this, but feel free to use graphical tools such as Postman or Insomnia.
-
 
 ### 3.1 Add a basic `asset`, `policy` and `contract-definition`
 
@@ -154,7 +160,8 @@ and it is the most basic transfer available.
 ## 6. Simplify negotiation and transfer using the EDR API
 
 In [step 5](#5-bob-transfers-data-from-alice) we saw how a contract negotiation and a transfer can be executed using the
-management API, first the negotiation and then the transfer phase, but there is a simpler way to do this: enter the EDR API.
+management API, first the negotiation and then the transfer phase, but there is a simpler way to do this: enter the EDR
+API.
 Using this convenient tool, we don't have to care about the intricacies of negotiation and transfer anymore, we can
 simply request an API token to Alice's proxy, and start sucking data out of it.
 We don't even need to worry about token expiry - the EDR API has a little gizmo that automatically refreshes the token

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -34,6 +34,11 @@ For the most bare-bones installation of the dataspace, execute the following com
 kind create cluster -n mxd
 # the next step is specific to KinD and will be different for other Kubernetes runtimes!
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+# wait until the ingress controller is ready
+kubectl wait --namespace ingress-nginx \
+  --for=condition=ready pod \
+  --selector=app.kubernetes.io/component=controller \
+  --timeout=90s
 cd <path/of/mxd>
 terraform init
 terraform apply
@@ -42,7 +47,8 @@ terraform apply
 
 Notice that the `kubectl apply` command deploys a Kubernetes Ingress Controller to the cluster and is required to reach
 our applications from outside the cluster. Specifically, it deploys an NGINX ingress controller. Notice also, that the
-command is *specific to KinD* and will likely not work on other Kubernetes runtimes or with other ingress controllers!
+command is *specific to KinD* and will likely not work on other Kubernetes runtimes (minikube, ...) or with other
+ingress controllers!
 
 Wait. Then wait some more. It will take a couple of minutes until all services are booted up. If your machine is a
 potato, it'll take even longer. Just get a coffee. Eventually, it should look similar to this:

--- a/mxd/ingress.tf
+++ b/mxd/ingress.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
-    name = "mxd-ingress"
+    name        = "mxd-ingress"
     annotations = {
       "nginx.ingress.kubernetes.io/rewrite-target" = "/$2"
       "nginx.ingress.kubernetes.io/use-regex"      = "true"
@@ -49,14 +49,3 @@ resource "kubernetes_ingress_v1" "mxd-ingress" {
     }
   }
 }
-
-#resource "helm_release" "ingress-nginx" {
-#  chart = "ingress-nginx"
-#  name  = "mxd-ingress"
-#  repository = "https://kubernetes.github.io/ingress-nginx"
-#  dependency_update = true
-#  force_update = true
-#  replace = true
-#  atomic = true
-#  recreate_pods = true
-#}

--- a/mxd/ingress.tf
+++ b/mxd/ingress.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
-    name        = "mxd-ingress"
+    name = "mxd-ingress"
     annotations = {
       "nginx.ingress.kubernetes.io/rewrite-target" = "/$2"
       "nginx.ingress.kubernetes.io/use-regex"      = "true"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -15,10 +15,6 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
-    kubectl = {
-      source  = "gavinbunney/kubectl"
-      version = "1.14.0"
-    }
   }
 }
 
@@ -34,10 +30,10 @@ provider "helm" {
 
 # First connector
 module "alice-connector" {
-  source        = "./modules/connector"
-  participantId = "alice"
-  database-host = local.pg-ip
-  database-name = "alice"
+  source               = "./modules/connector"
+  participantId        = "alice"
+  database-host        = local.pg-ip
+  database-name        = "alice"
   database-credentials = {
     user     = "postgres"
     password = "postgres"
@@ -54,10 +50,10 @@ module "alice-connector" {
 
 # Second connector
 module "bob-connector" {
-  source        = "./modules/connector"
-  participantId = "bob"
-  database-host = local.pg-ip
-  database-name = "bob"
+  source               = "./modules/connector"
+  participantId        = "bob"
+  database-host        = local.pg-ip
+  database-name        = "bob"
   database-credentials = {
     user     = "postgres"
     password = "postgres"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -34,10 +34,10 @@ provider "helm" {
 
 # First connector
 module "alice-connector" {
-  source               = "./modules/connector"
-  participantId        = "alice"
-  database-host        = local.pg-ip
-  database-name        = "alice"
+  source        = "./modules/connector"
+  participantId = "alice"
+  database-host = local.pg-ip
+  database-name = "alice"
   database-credentials = {
     user     = "postgres"
     password = "postgres"
@@ -54,10 +54,10 @@ module "alice-connector" {
 
 # Second connector
 module "bob-connector" {
-  source               = "./modules/connector"
-  participantId        = "bob"
-  database-host        = local.pg-ip
-  database-name        = "bob"
+  source        = "./modules/connector"
+  participantId = "bob"
+  database-host = local.pg-ip
+  database-name = "bob"
   database-credentials = {
     user     = "postgres"
     password = "postgres"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -15,6 +15,10 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "1.14.0"
+    }
   }
 }
 
@@ -30,10 +34,10 @@ provider "helm" {
 
 # First connector
 module "alice-connector" {
-  source        = "./modules/connector"
-  participantId = "alice"
-  database-host = local.pg-ip
-  database-name = "alice"
+  source               = "./modules/connector"
+  participantId        = "alice"
+  database-host        = local.pg-ip
+  database-name        = "alice"
   database-credentials = {
     user     = "postgres"
     password = "postgres"
@@ -50,10 +54,10 @@ module "alice-connector" {
 
 # Second connector
 module "bob-connector" {
-  source        = "./modules/connector"
-  participantId = "bob"
-  database-host = local.pg-ip
-  database-name = "bob"
+  source               = "./modules/connector"
+  participantId        = "bob"
+  database-host        = local.pg-ip
+  database-name        = "bob"
   database-credentials = {
     user     = "postgres"
     password = "postgres"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -30,10 +30,10 @@ provider "helm" {
 
 # First connector
 module "alice-connector" {
-  source               = "./modules/connector"
-  participantId        = "alice"
-  database-host        = local.pg-ip
-  database-name        = "alice"
+  source        = "./modules/connector"
+  participantId = "alice"
+  database-host = local.pg-ip
+  database-name = "alice"
   database-credentials = {
     user     = "postgres"
     password = "postgres"
@@ -50,10 +50,10 @@ module "alice-connector" {
 
 # Second connector
 module "bob-connector" {
-  source               = "./modules/connector"
-  participantId        = "bob"
-  database-host        = local.pg-ip
-  database-name        = "bob"
+  source        = "./modules/connector"
+  participantId = "bob"
+  database-host = local.pg-ip
+  database-name = "bob"
   database-credentials = {
     user     = "postgres"
     password = "postgres"

--- a/mxd/modules/connector/ingress.tf
+++ b/mxd/modules/connector/ingress.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
-    name = "${var.participantId}-ingress"
+    name        = "${var.participantId}-ingress"
     annotations = {
       "nginx.ingress.kubernetes.io/rewrite-target" = "/$2"
       "nginx.ingress.kubernetes.io/use-regex"      = "true"
@@ -39,4 +39,6 @@ resource "kubernetes_ingress_v1" "mxd-ingress" {
 
 locals {
   control-plane-service = "${var.participantId}-tractusx-connector-controlplane"
+  management_url        = "http://localhost/${var.participantId}/management/v2"
+  health_url            = "http://localhost/${var.participantId}/health"
 }

--- a/mxd/modules/connector/ingress.tf
+++ b/mxd/modules/connector/ingress.tf
@@ -1,6 +1,6 @@
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
-    name        = "${var.participantId}-ingress"
+    name = "${var.participantId}-ingress"
     annotations = {
       "nginx.ingress.kubernetes.io/rewrite-target" = "/$2"
       "nginx.ingress.kubernetes.io/use-regex"      = "true"

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -6,7 +6,7 @@ resource "kubernetes_service" "controlplane-service" {
     name = "${var.participantId}-nodeport"
   }
   spec {
-    type     = "NodePort"
+    type = "NodePort"
     selector = {
       "app.kubernetes.io/instance" = "${var.participantId}-controlplane"
       "app.kubernetes.io/name"     = "tractusx-connector-controlplane"

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -1,0 +1,19 @@
+# technically, the Helm chart for the connector already brings a Kubernetes service, but there is no
+# (easy) way to get ahold of it from terraform, so lets just declare another one
+
+resource "kubernetes_service" "controlplane-service" {
+  metadata {
+    name = "${var.participantId}-nodeport"
+  }
+  spec {
+    type     = "NodePort"
+    selector = {
+      "app.kubernetes.io/instance" = "${var.participantId}-controlplane"
+      "app.kubernetes.io/name"     = "tractusx-connector-controlplane"
+    }
+    port {
+      name = "management"
+      port = 8081
+    }
+  }
+}

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -6,7 +6,7 @@ resource "kubernetes_service" "controlplane-service" {
     name = "${var.participantId}-nodeport"
   }
   spec {
-    type = "NodePort"
+    type     = "NodePort"
     selector = {
       "app.kubernetes.io/instance" = "${var.participantId}-controlplane"
       "app.kubernetes.io/name"     = "tractusx-connector-controlplane"
@@ -14,6 +14,10 @@ resource "kubernetes_service" "controlplane-service" {
     port {
       name = "management"
       port = 8081
+    }
+    port {
+      name = "health"
+      port = 8080
     }
   }
 }

--- a/mxd/modules/connector/outputs.tf
+++ b/mxd/modules/connector/outputs.tf
@@ -8,3 +8,13 @@ output "client_secret" {
 output "database-name" {
   value = var.database-name
 }
+
+output "urls" {
+  value = {
+    management = local.management_url
+    health     = local.health_url
+  }
+}
+output "node-ip" {
+  value = kubernetes_service.controlplane-service.spec.0.cluster_ip
+}

--- a/mxd/outputs.tf
+++ b/mxd/outputs.tf
@@ -40,15 +40,13 @@ output "miw-database-pwd" {
 }
 
 output "bob-urls" {
-  value = {
-    management = "http://localhost/bob/management/v2"
-    health     = "http://localhost/bob/health"
-  }
+  value = module.bob-connector.urls
 }
 
-output "alice-management-url" {
-  value = {
-    management = "http://localhost/alice/management/v2"
-    health     = "http://localhost/alice/health"
-  }
+output "alice-urls" {
+  value = module.alice-connector.urls
+}
+
+output "bob-node-ip" {
+  value = module.bob-connector.node-ip
 }

--- a/mxd/outputs.tf
+++ b/mxd/outputs.tf
@@ -15,17 +15,40 @@ output "connector2-client-secret" {
 }
 
 output "postgres-url" {
-  value = "jdbc:postgresql://${local.pg-host}/${var.keycloak-database}"
+  value = "jdbc:postgresql://${local.pg-host}/"
 }
 
 output "keycloak-ip" {
   value = kubernetes_service.keycloak.spec.0.cluster_ip
 }
 
-output "keycloak-db-pwd" {
-  value = nonsensitive(local.kc-pg-pwd)
+output "keycloak-database-credentials" {
+  value = {
+    user     = var.miw-db-user
+    password = nonsensitive(local.kc-pg-pwd)
+    database = var.miw-database
+  }
 }
 
-output "miw-db-pwd" {
-  value = nonsensitive(local.miw-pg-pwd)
+output "miw-database-pwd" {
+
+  value = {
+    user     = var.keycloak-db-user
+    password = nonsensitive(local.miw-pg-pwd)
+    database = var.keycloak-database
+  }
+}
+
+output "bob-urls" {
+  value = {
+    management = "http://localhost/bob/management/v2"
+    health     = "http://localhost/bob/health"
+  }
+}
+
+output "alice-management-url" {
+  value = {
+    management = "http://localhost/alice/management/v2"
+    health     = "http://localhost/alice/health"
+  }
 }

--- a/mxd/postman/mxd-management-apis.json
+++ b/mxd/postman/mxd-management-apis.json
@@ -1,230 +1,49 @@
 {
 	"info": {
-		"_postman_id": "1466b775-e72c-483f-8707-ca87bf250f05",
+		"_postman_id": "a225ba72-ab82-4168-a6c2-b45a4521eee9",
 		"name": "MXD Management API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "647585"
 	},
 	"item": [
 		{
-			"name": "SeedData",
-			"item": [
-				{
-					"name": "Create Asset 1",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
-									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 1\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{MANAGEMENT_URL}}/assets",
-							"host": [
-								"{{MANAGEMENT_URL}}"
-							],
-							"path": [
-								"assets"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Asset 2",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
-									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{MANAGEMENT_URL}}/assets",
-							"host": [
-								"{{MANAGEMENT_URL}}"
-							],
-							"path": [
-								"assets"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Policy",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204 No Content (if new policy) or 409 Conflict (if policy already exists)\", function () {",
-									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"1\",\n    \"policy\": {\n\t\t\"@type\": \"Policy\",\n\t\t\"odrl:permission\" : [{\n\t\t\t\"odrl:action\" : \"USE\",\n\t\t\t\"odrl:constraint\" : {\n\t\t\t\t\"@type\": \"LogicalConstraint\",\n\t\t\t\t\"odrl:or\" : [{\n\t\t\t\t\t\"@type\" : \"Constraint\",\n\t\t\t\t\t\"odrl:leftOperand\" : \"BusinessPartnerNumber\",\n\t\t\t\t\t\"odrl:operator\" : {\n                        \"@id\": \"odrl:eq\"\n                    },\n\t\t\t\t\t\"odrl:rightOperand\" : \"BPNBOB\"\n\t\t\t\t}]\n\t\t\t}\n\t\t}]\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{MANAGEMENT_URL}}/policydefinitions",
-							"host": [
-								"{{MANAGEMENT_URL}}"
-							],
-							"path": [
-								"policydefinitions"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Contract Definition 1",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
-									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"1\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{MANAGEMENT_URL}}/contractdefinitions",
-							"host": [
-								"{{MANAGEMENT_URL}}"
-							],
-							"path": [
-								"contractdefinitions"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Create Contract Definition 2",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
-									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"2\"\n    }\n}",
-							"options": {
-								"raw": {
-									"language": "json"
-								}
-							}
-						},
-						"url": {
-							"raw": "{{MANAGEMENT_URL}}/contractdefinitions",
-							"host": [
-								"{{MANAGEMENT_URL}}"
-							],
-							"path": [
-								"contractdefinitions"
-							]
-						}
-					},
-					"response": []
-				}
-			],
+			"name": "Create Asset",
 			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				},
 				{
 					"listen": "test",
 					"script": {
-						"type": "text/javascript",
 						"exec": [
-							""
-						]
+							"pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+							"});"
+						],
+						"type": "text/javascript"
 					}
 				}
-			]
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/assets",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"assets"
+					]
+				}
+			},
+			"response": []
 		},
 		{
 			"name": "Get all Assets",
@@ -305,6 +124,45 @@
 					"path": [
 						"policydefinitions",
 						"{{POLICY_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create Policy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 204 No Content (if new policy) or 409 Conflict (if policy already exists)\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"1\",\n    \"policy\": {\n\t\t\"@type\": \"Policy\",\n\t\t\"odrl:permission\" : [{\n\t\t\t\"odrl:action\" : \"USE\",\n\t\t\t\"odrl:constraint\" : {\n\t\t\t\t\"@type\": \"LogicalConstraint\",\n\t\t\t\t\"odrl:or\" : [{\n\t\t\t\t\t\"@type\" : \"Constraint\",\n\t\t\t\t\t\"odrl:leftOperand\" : \"BusinessPartnerNumber\",\n\t\t\t\t\t\"odrl:operator\" : {\n                        \"@id\": \"odrl:eq\"\n                    },\n\t\t\t\t\t\"odrl:rightOperand\" : \"BPNBOB\"\n\t\t\t\t}]\n\t\t\t}\n\t\t}]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/policydefinitions",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"policydefinitions"
 					]
 				}
 			},
@@ -443,6 +301,45 @@
 					"path": [
 						"contractdefinitions",
 						"{{CONTRACT_DEFINITION_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Create Contract Definition",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
+							"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"1\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractdefinitions",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractdefinitions"
 					]
 				}
 			},

--- a/mxd/postman/mxd-management-apis.json
+++ b/mxd/postman/mxd-management-apis.json
@@ -1,0 +1,1031 @@
+{
+	"info": {
+		"_postman_id": "1466b775-e72c-483f-8707-ca87bf250f05",
+		"name": "MXD Management API",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "647585"
+	},
+	"item": [
+		{
+			"name": "SeedData",
+			"item": [
+				{
+					"name": "Create Asset 1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 1\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{MANAGEMENT_URL}}/assets",
+							"host": [
+								"{{MANAGEMENT_URL}}"
+							],
+							"path": [
+								"assets"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Asset 2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{MANAGEMENT_URL}}/assets",
+							"host": [
+								"{{MANAGEMENT_URL}}"
+							],
+							"path": [
+								"assets"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Policy",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204 No Content (if new policy) or 409 Conflict (if policy already exists)\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"1\",\n    \"policy\": {\n\t\t\"@type\": \"Policy\",\n\t\t\"odrl:permission\" : [{\n\t\t\t\"odrl:action\" : \"USE\",\n\t\t\t\"odrl:constraint\" : {\n\t\t\t\t\"@type\": \"LogicalConstraint\",\n\t\t\t\t\"odrl:or\" : [{\n\t\t\t\t\t\"@type\" : \"Constraint\",\n\t\t\t\t\t\"odrl:leftOperand\" : \"BusinessPartnerNumber\",\n\t\t\t\t\t\"odrl:operator\" : {\n                        \"@id\": \"odrl:eq\"\n                    },\n\t\t\t\t\t\"odrl:rightOperand\" : \"BPNBOB\"\n\t\t\t\t}]\n\t\t\t}\n\t\t}]\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{MANAGEMENT_URL}}/policydefinitions",
+							"host": [
+								"{{MANAGEMENT_URL}}"
+							],
+							"path": [
+								"policydefinitions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Contract Definition 1",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"1\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{MANAGEMENT_URL}}/contractdefinitions",
+							"host": [
+								"{{MANAGEMENT_URL}}"
+							],
+							"path": [
+								"contractdefinitions"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create Contract Definition 2",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
+									"    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"2\"\n    }\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{MANAGEMENT_URL}}/contractdefinitions",
+							"host": [
+								"{{MANAGEMENT_URL}}"
+							],
+							"path": [
+								"contractdefinitions"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Get all Assets",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/assets/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"assets",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Asset by ID",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/assets/{{ASSET_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"assets",
+						"{{ASSET_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete Asset by ID",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/assets/{{ASSET_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"assets",
+						"{{ASSET_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Policy by ID",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"{{POLICY_ID}}\",\n    \"policy\": {\n        \"prohibitions\": [],\n        \"obligations\": [],\n        \"permissions\": [\n            {\n                \"edctype\": \"dataspaceconnector:permission\",\n                \"action\": {\n                    \"type\": \"USE\"\n                },\n                \"constraints\": []\n            }\n        ]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/policydefinitions/{{POLICY_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"policydefinitions",
+						"{{POLICY_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all Policies",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"id\": \"{{POLICY_ID}}\",\n    \"policy\": {\n        \"prohibitions\": [],\n        \"obligations\": [],\n        \"permissions\": [\n            {\n                \"edctype\": \"dataspaceconnector:permission\",\n                \"action\": {\n                    \"type\": \"USE\"\n                },\n                \"constraints\": []\n            }\n        ]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/policydefinitions/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"policydefinitions",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delte Policy by ID",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"{{POLICY_ID}}\",\n    \"policy\": {\n        \"prohibitions\": [],\n        \"obligations\": [],\n        \"permissions\": [\n            {\n                \"edctype\": \"dataspaceconnector:permission\",\n                \"action\": {\n                    \"type\": \"USE\"\n                },\n                \"constraints\": []\n            }\n        ]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/policydefinitions/{{POLICY_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"policydefinitions",
+						"{{POLICY_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Contract Definition by ID",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"{{POLICY_ID}}\",\n    \"policy\": {\n        \"prohibitions\": [],\n        \"obligations\": [],\n        \"permissions\": [\n            {\n                \"edctype\": \"dataspaceconnector:permission\",\n                \"action\": {\n                    \"type\": \"USE\"\n                },\n                \"constraints\": []\n            }\n        ]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractdefinitions/{{CONTRACT_DEFINITION_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractdefinitions",
+						"{{CONTRACT_DEFINITION_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all Contract Definitiions",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractdefinitions/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractdefinitions",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delte Contract Definition",
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"id\": \"{{POLICY_ID}}\",\n    \"policy\": {\n        \"prohibitions\": [],\n        \"obligations\": [],\n        \"permissions\": [\n            {\n                \"edctype\": \"dataspaceconnector:permission\",\n                \"action\": {\n                    \"type\": \"USE\"\n                },\n                \"constraints\": []\n            }\n        ]\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractdefinitions/{{CONTRACT_DEFINITION_ID}}",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractdefinitions",
+						"{{CONTRACT_DEFINITION_ID}}"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Query Catalog",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n    \"@context\": {},\r\n    \"protocol\": \"dataspace-protocol-http\",\r\n    \"providerUrl\": \"{{PROVIDER_PROTOCOL_URL}}\",\r\n    \"querySpec\": {\r\n        \"offset\": 0,\r\n        \"limit\": 100,\r\n        \"filter\": \"\",\r\n        \"range\": {\r\n            \"from\": 0,\r\n            \"to\": 100\r\n        },\r\n        \"criterion\": \"\"\r\n    }\r\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/catalog/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"catalog",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Initiate Negotation",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"@context\": {\n\t\t\"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n\t},\n\t\"@type\": \"NegotiationInitiateRequestDto\",\n\t\"connectorAddress\": \"{{PROVIDER_PROTOCOL_URL}}\",\n\t\"protocol\": \"dataspace-protocol-http\",\n\t\"connectorId\": \"{{PROVIDER_ID}}\",\n\t\"providerId\": \"{{PROVIDER_ID}}\",\n\t\"offer\": {\n\t\t\"offerId\": \"MQ==:MQ==:ZDM4Nzk3NmUtZjA0Ny00ZmNjLWFhNWItYjQwYmVkMDBhZGYy\",\n\t\t\"assetId\": \"{{ASSET_ID}}\",\n\t\t\"policy\": {\n\t\t\t\"@type\": \"odrl:Set\",\n\t\t\t\"odrl:permission\": {\n\t\t\t\t\"odrl:target\": \"{{ASSET_ID}}\",\n\t\t\t\t\"odrl:action\": {\n\t\t\t\t\t\"odrl:type\": \"USE\"\n\t\t\t\t},\n\t\t\t\t\"odrl:constraint\": {\n\t\t\t\t\t\"odrl:or\": {\n\t\t\t\t\t\t\"odrl:leftOperand\": \"BusinessPartnerNumber\",\n\t\t\t\t\t\t\"odrl:operator\": {\n                            \"@id\": \"odrl:eq\"\n                        },\n\t\t\t\t\t\t\"odrl:rightOperand\": \"{{POLICY_BPN}}\"\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t},\n\t\t\t\"odrl:prohibition\": [],\n\t\t\t\"odrl:obligation\": [],\n\t\t\t\"odrl:target\": \"{{ASSET_ID}}\"\n\t\t}\n\t}\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractnegotiations",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractnegotiations"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all Negotations",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractnegotiations/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractnegotiations",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Cancel Negotation by ID",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/contractnegotiations/7cff6ecb-7e5e-40b8-b101-eba3f2045b1f/cancel",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"contractnegotiations",
+						"7cff6ecb-7e5e-40b8-b101-eba3f2045b1f",
+						"cancel"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Initiate Transfer",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							"pm.collectionVariables.set(\"TRANSFER_ID\", Math.random());"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"TRANSFER_PROCESS_ID\", jsonData.id);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"connectorAddress\": \"{{PROVIDER_PROTOCOL_URL}}\",\n    \"connectorId\": \"{{PROVIDER_ID}}\",\n    \"contractId\": \"MQ==:MQ==:NzgyYTVlMWMtY2UxNi00NDZmLThkZGQtMDc4MWZkMDg1NDU0\",\n    \"dataDestination\": {\n        \"type\": \"HttpProxy\"\n    },\n    \"managedResources\": false,\n    \"privateProperties\": {\n        \"receiverHttpEndpoint\": \"{{BACKEND_SERVICE}}\"\n    },\n    \"protocol\": \"dataspace-protocol-http\",\n    \"transferType\": {\n        \"contentType\": \"application/octet-stream\",\n        \"isFinite\": true\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/transferprocesses",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"transferprocesses"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Transfer by ID",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/transferprocesses/8e428b80-46a5-4325-87e5-592518f7666b",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"transferprocesses",
+						"8e428b80-46a5-4325-87e5-592518f7666b"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get all Transfers",
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{MANAGEMENT_URL}}/transferprocesses/request",
+					"host": [
+						"{{MANAGEMENT_URL}}"
+					],
+					"path": [
+						"transferprocesses",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Initiate EDR Negotation",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"@context\": {\n\t\t\"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n\t},\n\t\"@type\": \"NegotiationInitiateRequestDto\",\n\t\"connectorAddress\": \"{{PROVIDER_PROTOCOL_URL}}\",\n\t\"protocol\": \"dataspace-protocol-http\",\n\t\"connectorId\": \"{{PROVIDER_ID}}\",\n\t\"providerId\": \"{{PROVIDER_ID}}\",\n\t\"offer\": {\n\t\t\"offerId\": \"MQ==:MQ==:ZDM4Nzk3NmUtZjA0Ny00ZmNjLWFhNWItYjQwYmVkMDBhZGYy\",\n\t\t\"assetId\": \"{{ASSET_ID}}\",\n\t\t\"policy\": {\n\t\t\t\"@type\": \"odrl:Set\",\n\t\t\t\"odrl:permission\": {\n\t\t\t\t\"odrl:target\": \"{{ASSET_ID}}\",\n\t\t\t\t\"odrl:action\": {\n\t\t\t\t\t\"odrl:type\": \"USE\"\n\t\t\t\t},\n\t\t\t\t\"odrl:constraint\": {\n\t\t\t\t\t\"odrl:or\": {\n\t\t\t\t\t\t\"odrl:leftOperand\": \"BusinessPartnerNumber\",\n\t\t\t\t\t\t\"odrl:operator\": {\n                            \"@id\": \"odrl:eq\"\n                        },\n\t\t\t\t\t\t\"odrl:rightOperand\": \"{{POLICY_BPN}}\"\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t},\n\t\t\t\"odrl:prohibition\": [],\n\t\t\t\"odrl:obligation\": [],\n\t\t\t\"odrl:target\": \"{{ASSET_ID}}\"\n\t\t}\n\t}\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_ADAPTER_URL}}/edrs",
+					"host": [
+						"{{CONSUMER_ADAPTER_URL}}"
+					],
+					"path": [
+						"edrs"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Query EDRs Cached",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_ADAPTER_URL}}/edrs?assetId={{ASSET_ID}}",
+					"host": [
+						"{{CONSUMER_ADAPTER_URL}}"
+					],
+					"path": [
+						"edrs"
+					],
+					"query": [
+						{
+							"key": "assetId",
+							"value": "{{ASSET_ID}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get EDR by tp ID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_ADAPTER_URL}}/edrs/e1e986be-3ac3-4166-8fa9-b44be00a37ba",
+					"host": [
+						"{{CONSUMER_ADAPTER_URL}}"
+					],
+					"path": [
+						"edrs",
+						"e1e986be-3ac3-4166-8fa9-b44be00a37ba"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Asset Data with proxy",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"endpointUrl\": \"http://plato-dataplane:8080/api/gateway/aas/1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:8186/proxy/aas/request",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "8186",
+					"path": [
+						"proxy",
+						"aas",
+						"request"
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"auth": {
+		"type": "apikey",
+		"apikey": [
+			{
+				"key": "value",
+				"value": "password",
+				"type": "string"
+			},
+			{
+				"key": "key",
+				"value": "X-Api-Key",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "MANAGEMENT_URL",
+			"value": "http://localhost/bob/management/v2"
+		},
+		{
+			"key": "PROVIDER_PROTOCOL_URL",
+			"value": "http://plato-controlplane:8084/api/v1/dsp"
+		},
+		{
+			"key": "ASSET_ID",
+			"value": "1",
+			"type": "default"
+		},
+		{
+			"key": "POLICY_ID",
+			"value": "1",
+			"type": "default"
+		},
+		{
+			"key": "CONTRACT_POLICY_ID",
+			"value": "1",
+			"type": "default"
+		},
+		{
+			"key": "ACCESS_POLICY_ID",
+			"value": "1",
+			"type": "default"
+		},
+		{
+			"key": "CONTRACT_DEFINITION_ID",
+			"value": "1",
+			"type": "default"
+		},
+		{
+			"key": "POLICY_BPN",
+			"value": "BPNBOB",
+			"type": "default"
+		},
+		{
+			"key": "NEGOTIATION_ID",
+			"value": ""
+		},
+		{
+			"key": "AGREEMENT_ID",
+			"value": ""
+		},
+		{
+			"key": "TRANSFER_ID",
+			"value": ""
+		},
+		{
+			"key": "TRANSFER_PROCESS_ID",
+			"value": ""
+		},
+		{
+			"key": "BACKEND_SERVICE",
+			"value": "http://backend:8080",
+			"type": "string"
+		},
+		{
+			"key": "AGREEMENT-ID",
+			"value": ""
+		},
+		{
+			"key": "authCode",
+			"value": ""
+		},
+		{
+			"key": "PROVIDER_ID",
+			"value": "BPNPLATO",
+			"type": "string"
+		},
+		{
+			"key": "EDC_NAMESPACE",
+			"value": "https://w3id.org/edc/v0.0.1/ns/",
+			"type": "string"
+		},
+		{
+			"key": "CONSUMER_ADAPTER_URL",
+			"value": "http://localhost:31364/management",
+			"type": "string"
+		}
+	]
+}

--- a/mxd/postman/mxd-seed.json
+++ b/mxd/postman/mxd-seed.json
@@ -1,0 +1,349 @@
+{
+  "info": {
+    "_postman_id": "1466b775-e72c-483f-8707-ca87bf250f05",
+    "name": "MXD Management API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "647585"
+  },
+  "item": [
+    {
+      "name": "SeedData",
+      "item": [
+        {
+          "name": "Create Asset 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 1\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{MANAGEMENT_URL}}/assets",
+              "host": [
+                "{{MANAGEMENT_URL}}"
+              ],
+              "path": [
+                "assets"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Asset 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204 No Content (if new asset) or 409 Conflict (if asset already exists)\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{MANAGEMENT_URL}}/assets",
+              "host": [
+                "{{MANAGEMENT_URL}}"
+              ],
+              "path": [
+                "assets"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Policy",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204 No Content (if new policy) or 409 Conflict (if policy already exists)\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"@type\": \"PolicyDefinitionRequestDto\",\n    \"@id\": \"1\",\n    \"policy\": {\n\t\t\"@type\": \"Policy\",\n\t\t\"odrl:permission\" : [{\n\t\t\t\"odrl:action\" : \"USE\",\n\t\t\t\"odrl:constraint\" : {\n\t\t\t\t\"@type\": \"LogicalConstraint\",\n\t\t\t\t\"odrl:or\" : [{\n\t\t\t\t\t\"@type\" : \"Constraint\",\n\t\t\t\t\t\"odrl:leftOperand\" : \"BusinessPartnerNumber\",\n\t\t\t\t\t\"odrl:operator\" : {\n                        \"@id\": \"odrl:eq\"\n                    },\n\t\t\t\t\t\"odrl:rightOperand\" : \"{{POLICY_BPN}}\"\n\t\t\t\t}]\n\t\t\t}\n\t\t}]\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{MANAGEMENT_URL}}/policydefinitions",
+              "host": [
+                "{{MANAGEMENT_URL}}"
+              ],
+              "path": [
+                "policydefinitions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Contract Definition 1",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"1\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{MANAGEMENT_URL}}/contractdefinitions",
+              "host": [
+                "{{MANAGEMENT_URL}}"
+              ],
+              "path": [
+                "contractdefinitions"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "Create Contract Definition 2",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 204 No Content (if new contract definition) or 409 Conflict (if contract deifinition already exists)\", function () {",
+                  "    pm.expect(pm.response.code).to.be.oneOf([200, 204, 409])",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"2\"\n    }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{MANAGEMENT_URL}}/contractdefinitions",
+              "host": [
+                "{{MANAGEMENT_URL}}"
+              ],
+              "path": [
+                "contractdefinitions"
+              ]
+            }
+          },
+          "response": []
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              ""
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "auth": {
+    "type": "apikey",
+    "apikey": [
+      {
+        "key": "value",
+        "value": "password",
+        "type": "string"
+      },
+      {
+        "key": "key",
+        "value": "X-Api-Key",
+        "type": "string"
+      }
+    ]
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "MANAGEMENT_URL",
+      "value": "http://localhost/bob/management/v2"
+    },
+    {
+      "key": "PROVIDER_PROTOCOL_URL",
+      "value": "http://plato-controlplane:8084/api/v1/dsp"
+    },
+    {
+      "key": "ASSET_ID",
+      "value": "1",
+      "type": "default"
+    },
+    {
+      "key": "POLICY_ID",
+      "value": "1",
+      "type": "default"
+    },
+    {
+      "key": "CONTRACT_POLICY_ID",
+      "value": "1",
+      "type": "default"
+    },
+    {
+      "key": "ACCESS_POLICY_ID",
+      "value": "1",
+      "type": "default"
+    },
+    {
+      "key": "CONTRACT_DEFINITION_ID",
+      "value": "1",
+      "type": "default"
+    },
+    {
+      "key": "POLICY_BPN",
+      "value": "BPNBOB",
+      "type": "default"
+    },
+    {
+      "key": "NEGOTIATION_ID",
+      "value": ""
+    },
+    {
+      "key": "AGREEMENT_ID",
+      "value": ""
+    },
+    {
+      "key": "TRANSFER_ID",
+      "value": ""
+    },
+    {
+      "key": "TRANSFER_PROCESS_ID",
+      "value": ""
+    },
+    {
+      "key": "BACKEND_SERVICE",
+      "value": "http://backend:8080",
+      "type": "string"
+    },
+    {
+      "key": "AGREEMENT-ID",
+      "value": ""
+    },
+    {
+      "key": "authCode",
+      "value": ""
+    },
+    {
+      "key": "PROVIDER_ID",
+      "value": "BPNPLATO",
+      "type": "string"
+    },
+    {
+      "key": "EDC_NAMESPACE",
+      "value": "https://w3id.org/edc/v0.0.1/ns/",
+      "type": "string"
+    },
+    {
+      "key": "CONSUMER_ADAPTER_URL",
+      "value": "http://localhost:31364/management",
+      "type": "string"
+    }
+  ]
+}

--- a/mxd/postman/mxd-seed.json
+++ b/mxd/postman/mxd-seed.json
@@ -68,7 +68,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+              "raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"2\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -185,7 +185,7 @@
             "header": [],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"@context\": {},\n    \"@id\": \"1\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"2\"\n    }\n}",
+              "raw": "{\n    \"@context\": {},\n    \"@id\": \"2\",\n    \"@type\": \"ContractDefinition\",\n    \"accessPolicyId\": \"1\",\n    \"contractPolicyId\": \"1\",\n    \"assetsSelector\" : {\n        \"@type\" : \"CriterionDto\",\n        \"operandLeft\": \"{{EDC_NAMESPACE}}id\",\n        \"operator\": \"=\",\n        \"operandRight\": \"2\"\n    }\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -1,3 +1,7 @@
+# This job's purpose is to supply some very basic master data to both connectors.
+# It will each create two assets, a policy and two contract definitions.
+# To achieve that, the Job mounts a Postman collection as ConfigMap, and runs it using newman
+
 resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
   metadata {
     name = "seed-connectors"

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -1,0 +1,75 @@
+resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
+  metadata {
+    name = "seed-connectors"
+  }
+  spec {
+    // run only once
+    completions                = 1
+    completion_mode            = "NonIndexed"
+    // clean up any job pods after 90 seconds, failed or succeeded
+    ttl_seconds_after_finished = "90"
+    template {
+      metadata {
+        name = "seed-connectors"
+      }
+      spec {
+        // this container seeds data to the BOB connector
+        container {
+          name    = "newman-bob"
+          image   = "postman/newman:ubuntu"
+          command = [
+            "newman", "run",
+            "--folder", "SeedData",
+            "--env-var",
+            "MANAGEMENT_URL=http://${module.bob-connector.node-ip}:8081/management/v2",
+            "--env-var", "POLICY_BPN=BPNALICE",
+            "/opt/collection/${local.newman_collection_name}"
+          ]
+          volume_mount {
+            mount_path = "/opt/collection"
+            name       = "seed-collection"
+          }
+        }
+        // this container seeds data to the ALICE connector
+        container {
+          name    = "newman-alice"
+          image   = "postman/newman:ubuntu"
+          command = [
+            "newman", "run",
+            "--folder", "SeedData",
+            "--env-var",
+            "MANAGEMENT_URL=http://${module.alice-connector.node-ip}:8081/management/v2",
+            "--env-var", "POLICY_BPN=BPNBOB",
+            "/opt/collection/${local.newman_collection_name}"
+          ]
+          volume_mount {
+            mount_path = "/opt/collection"
+            name       = "seed-collection"
+          }
+        }
+        volume {
+          name = "seed-collection"
+          config_map {
+            name = kubernetes_config_map.seed-collection.metadata.0.name
+          }
+        }
+        // only restart when failed
+        restart_policy = "OnFailure"
+      }
+    }
+  }
+}
+
+resource "kubernetes_config_map" "seed-collection" {
+  metadata {
+    name = "seed-collection"
+  }
+  data = {
+    (local.newman_collection_name) = file("./postman/mxd-seed.json")
+  }
+}
+
+locals {
+  newman_collection_name = "mxd-seed.json"
+}
+

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -10,8 +10,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
   }
   spec {
     // run only once
-    completions                = 1
-    completion_mode            = "NonIndexed"
+    completions     = 1
+    completion_mode = "NonIndexed"
     // clean up any job pods after 90 seconds, failed or succeeded
     ttl_seconds_after_finished = "90"
     template {
@@ -21,8 +21,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
       spec {
         // this container seeds data to the BOB connector
         container {
-          name    = "newman-bob"
-          image   = "postman/newman:ubuntu"
+          name  = "newman-bob"
+          image = "postman/newman:ubuntu"
           command = [
             "newman", "run",
             "--folder", "SeedData",
@@ -38,8 +38,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
         }
         // this container seeds data to the ALICE connector
         container {
-          name    = "newman-alice"
-          image   = "postman/newman:ubuntu"
+          name  = "newman-alice"
+          image = "postman/newman:ubuntu"
           command = [
             "newman", "run",
             "--folder", "SeedData",
@@ -52,22 +52,6 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
             mount_path = "/opt/collection"
             name       = "seed-collection"
           }
-        }
-        init_container {
-          name    = "wait-for-bob"
-          image   = "curlimages/curl:latest"
-          command = ["/bin/sh", "-c"]
-          args    = [
-            "while [ $(curl -sw '%%{http_code}' http://${module.bob-connector.node-ip}:8080/api/check/readiness -o /dev/null) -ne 200 ]; do sleep 5; echo 'Waiting for bob'; done",
-          ]
-        }
-        init_container {
-          name    = "wait-for-alice"
-          image   = "curlimages/curl:latest"
-          command = ["/bin/sh", "-c"]
-          args    = [
-            "while [ $(curl -sw '%%{http_code}' http://${module.alice-connector.node-ip}:8080/api/check/readiness -o /dev/null) -ne 200 ]; do sleep 5; echo 'Waiting for alice'; done",
-          ]
         }
         volume {
           name = "seed-collection"

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -8,8 +8,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
   }
   spec {
     // run only once
-    completions                = 1
-    completion_mode            = "NonIndexed"
+    completions     = 1
+    completion_mode = "NonIndexed"
     // clean up any job pods after 90 seconds, failed or succeeded
     ttl_seconds_after_finished = "90"
     template {
@@ -19,8 +19,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
       spec {
         // this container seeds data to the BOB connector
         container {
-          name    = "newman-bob"
-          image   = "postman/newman:ubuntu"
+          name  = "newman-bob"
+          image = "postman/newman:ubuntu"
           command = [
             "newman", "run",
             "--folder", "SeedData",
@@ -36,8 +36,8 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
         }
         // this container seeds data to the ALICE connector
         container {
-          name    = "newman-alice"
-          image   = "postman/newman:ubuntu"
+          name  = "newman-alice"
+          image = "postman/newman:ubuntu"
           command = [
             "newman", "run",
             "--folder", "SeedData",


### PR DESCRIPTION
## WHAT
This PR adds some very basic objects (Assets, policies, contract-defs) to both the `alice` and `bob` connector, using a tool called `newman`, packaged as Kubernetes Job. That job is declared in `mxd/seed_data.tf`.

## WHY
It is important for people to be able to verify that their local setup is in fact working and to see.

## FURTHER NOTES
the README.md has been updated accordingly.