### PR TITLE
feat: fix issuer and audience for MXD

### DIFF
--- a/mxd/keycloak.tf
+++ b/mxd/keycloak.tf
@@ -75,7 +75,7 @@ resource "kubernetes_config_map" "keycloak_env" {
     KEYCLOAK_ADMIN             = "admin"
     KEYCLOAK_ADMIN_PASSWORD    = "admin"
     # the KC_HOSTNAME must be known in advance, so that Keycloak's token contain valid `iss` claims
-    KC_HOSTNAME       = local.keycloak-url
+    KC_HOSTNAME       = local.keycloak-ip
     KC_HEALTH_ENABLED = true
   }
 }

--- a/mxd/keycloak.tf
+++ b/mxd/keycloak.tf
@@ -38,7 +38,7 @@ resource "kubernetes_deployment" "keycloak" {
               name = kubernetes_config_map.keycloak_env.metadata[0].name
             }
           }
-          # Uncomment this to assign (more) resources
+          #           Uncomment this to assign (more) resources
           #          resources {
           #            limits = {
           #              cpu    = "2"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -41,7 +41,7 @@ module "alice-connector" {
   ssi-config = {
     miw-url            = "http://${kubernetes_service.miw.spec.0.cluster_ip}:${var.miw-api-port}"
     miw-authorityId    = "BPNL000000000000"
-    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.miw-api-port}"
+    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}"
     oauth-clientid     = "miw_private_client"
     oauth-secretalias  = "client_secret_alias"
     oauth-clientsecret = "miw_private_client"
@@ -61,8 +61,8 @@ module "bob-connector" {
   ssi-config = {
     miw-url            = "http://${kubernetes_service.miw.spec.0.cluster_ip}:${var.miw-api-port}"
     miw-authorityId    = "BPNL000000000000"
-    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.miw-api-port}"
-    oauth-clientid     = "miw_private_client2"
+    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}"
+    oauth-clientid     = "miw_private_client"
     oauth-secretalias  = "client_secret_alias"
     oauth-clientsecret = "miw_private_client"
   }

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -39,9 +39,9 @@ module "alice-connector" {
     password = "postgres"
   }
   ssi-config = {
-    miw-url            = "http://${kubernetes_service.miw.spec.0.cluster_ip}:${var.miw-api-port}"
+    miw-url            = "http://${local.miw-ip}:${var.miw-api-port}"
     miw-authorityId    = "BPNL000000000000"
-    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}"
+    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}/realms/miw_test/protocol/openid-connect/token"
     oauth-clientid     = "miw_private_client"
     oauth-secretalias  = "client_secret_alias"
     oauth-clientsecret = "miw_private_client"
@@ -59,9 +59,9 @@ module "bob-connector" {
     password = "postgres"
   }
   ssi-config = {
-    miw-url            = "http://${kubernetes_service.miw.spec.0.cluster_ip}:${var.miw-api-port}"
+    miw-url            = "http://${local.miw-ip}:${var.miw-api-port}"
     miw-authorityId    = "BPNL000000000000"
-    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}"
+    oauth-tokenUrl     = "http://${kubernetes_service.keycloak.spec.0.cluster_ip}:${var.keycloak-port}/realms/miw_test/protocol/openid-connect/token"
     oauth-clientid     = "miw_private_client"
     oauth-secretalias  = "client_secret_alias"
     oauth-clientsecret = "miw_private_client"

--- a/mxd/miw.tf
+++ b/mxd/miw.tf
@@ -96,15 +96,13 @@ resource "kubernetes_service" "miw" {
       App = kubernetes_deployment.miw.spec.0.template.0.metadata[0].labels.App
     }
     port {
-      name        = "miw-app-port"
-      port        = var.miw-api-port
-      target_port = var.miw-api-port
+      name = "miw-app-port"
+      port = var.miw-api-port
     }
 
     port {
-      port        = 8090
-      name        = "mgmt-port"
-      target_port = 8090
+      port = 8090
+      name = "mgmt-port"
     }
   }
 }

--- a/mxd/miw.tf
+++ b/mxd/miw.tf
@@ -76,9 +76,9 @@ resource "kubernetes_config_map" "miw-config" {
     VC_SCHEMA_LINK                  = "https://www.w3.org/2018/credentials/v1, https://catenax-ng.github.io/product-core-schemas/businessPartnerData.json"
     VC_EXPIRY_DATE                  = "01-01-2025"
     SUPPORTED_FRAMEWORK_VC_TYPES    = "cx-behavior-twin=Behavior Twin,cx-pcf=PCF,cx-quality=Quality,cx-resiliency=Resiliency,cx-sustainability=Sustainability,cx-traceability=ID_3.0_Trace"
-    MIW_HOST_NAME                   = "localhost:8000"
+    MIW_HOST_NAME                   = "${local.miw-ip}:${var.miw-api-port}"
     ENFORCE_HTTPS_IN_DID_RESOLUTION = false
-    AUTH_SERVER_URL                 = "http://${local.keycloak-url}"
+    AUTH_SERVER_URL                 = "http://${local.keycloak-ip}:${var.keycloak-port}"
     DEV_ENVIRONMENT                 = "docker"
     APPLICATION_PORT                = var.miw-api-port
     MANAGEMENT_PORT                 = 8090
@@ -95,6 +95,9 @@ resource "kubernetes_service" "miw" {
     selector = {
       App = kubernetes_deployment.miw.spec.0.template.0.metadata[0].labels.App
     }
+    session_affinity = "ClientIP"
+    # we need a stable IP, otherwise there will be a cycle with the issuer
+    cluster_ip = local.miw-ip
     port {
       name = "miw-app-port"
       port = var.miw-api-port
@@ -105,4 +108,9 @@ resource "kubernetes_service" "miw" {
       name = "mgmt-port"
     }
   }
+}
+
+locals {
+  miw-ip  = "10.96.81.222"
+  miw-url = "${local.miw-ip}:${var.miw-api-port}"
 }

--- a/mxd/modules/connector/main.tf
+++ b/mxd/modules/connector/main.tf
@@ -25,6 +25,9 @@ resource "helm_release" "connector" {
     }),
     yamlencode({
       controlplane : {
+        env : {
+          "TX_SSI_ENDPOINT_AUDIENCE" : "http://${kubernetes_service.controlplane-service.spec.0.cluster_ip}:8084/api/v1/dsp"
+        }
         ssi : {
           miw : {
             url : var.ssi-config.miw-url

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -23,5 +23,9 @@ resource "kubernetes_service" "controlplane-service" {
       name = "protocol"
       port = 8084
     }
+    port {
+      name = "debug"
+      port = 1044
+    }
   }
 }

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -19,5 +19,9 @@ resource "kubernetes_service" "controlplane-service" {
       name = "health"
       port = 8080
     }
+    port {
+      name = "protocol"
+      port = 8084
+    }
   }
 }

--- a/mxd/modules/connector/values.yaml
+++ b/mxd/modules/connector/values.yaml
@@ -24,6 +24,9 @@
 participant:
   id: "test-participant"
 controlplane:
+  debug:
+    enabled: true
+    port: 1044
   service:
     type: NodePort
   endpoints:

--- a/mxd/outputs.tf
+++ b/mxd/outputs.tf
@@ -18,9 +18,10 @@ output "postgres-url" {
   value = "jdbc:postgresql://${local.pg-host}/"
 }
 
-output "keycloak-ip" {
+output "keycloak-cluster-ip" {
   value = kubernetes_service.keycloak.spec.0.cluster_ip
 }
+
 
 output "keycloak-database-credentials" {
   value = {
@@ -30,7 +31,10 @@ output "keycloak-database-credentials" {
   }
 }
 
-output "miw-database-pwd" {
+output "miw-cluster-ip" {
+  value = local.miw-ip
+}
+output "miw-database-credentials" {
 
   value = {
     user     = var.keycloak-db-user
@@ -49,4 +53,8 @@ output "alice-urls" {
 
 output "bob-node-ip" {
   value = module.bob-connector.node-ip
+}
+
+output "alice-node-ip" {
+  value = module.alice-connector.node-ip
 }

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -43,7 +43,7 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
             "newman", "run",
             "--folder", "SeedData",
             "--env-var", "MANAGEMENT_URL=http://${module.alice-connector.node-ip}:8081/management/v2",
-            "--env-var", "POLICY_BPN=BPNBOB",
+            "--env-var", "POLICY_BPN=BPNL000000000000",
             "/opt/collection/${local.newman_collection_name}"
           ]
           volume_mount {

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -26,8 +26,7 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
           command = [
             "newman", "run",
             "--folder", "SeedData",
-            "--env-var",
-            "MANAGEMENT_URL=http://${module.bob-connector.node-ip}:8081/management/v2",
+            "--env-var", "MANAGEMENT_URL=http://${module.bob-connector.node-ip}:8081/management/v2",
             "--env-var", "POLICY_BPN=BPNALICE",
             "/opt/collection/${local.newman_collection_name}"
           ]
@@ -43,8 +42,7 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
           command = [
             "newman", "run",
             "--folder", "SeedData",
-            "--env-var",
-            "MANAGEMENT_URL=http://${module.alice-connector.node-ip}:8081/management/v2",
+            "--env-var", "MANAGEMENT_URL=http://${module.alice-connector.node-ip}:8081/management/v2",
             "--env-var", "POLICY_BPN=BPNBOB",
             "/opt/collection/${local.newman_collection_name}"
           ]


### PR DESCRIPTION
## WHAT
This PR fixes some issues we previously had with the `iss` and `aud` claims, which caused DSP requests to fail.

IN addition, the connector service now exposes a debug port (`1044`) to enable remote-debugging.

## WHY
be able to execute catalog requests etc.