### PR TITLE
chore: fix license header

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
-          cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,yaml,yml,kts,sql} --exclude-dir={.gradle,\*\openapi} ."
+          cmd="grep -riL \"SPDX-License-Identifier: Apache-2.0\" --include=\*.{java,ts,html,css,yaml,yml,kts,sql,tf} --exclude-dir={.gradle,\*\openapi} ."
           violations=$(eval $cmd | wc -l)
           if [[ $violations -ne 0 ]] ; then
             echo "$violations files without license headers were found:";

--- a/edc-policy-playground/src/app/app.component.html
+++ b/edc-policy-playground/src/app/app.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <app-header> </app-header>

--- a/edc-policy-playground/src/app/app.component.spec.ts
+++ b/edc-policy-playground/src/app/app.component.spec.ts
@@ -1,3 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
 import { TestBed } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 import { AppHeaderComponent } from './components/header/header.component';

--- a/edc-policy-playground/src/app/app.component.ts
+++ b/edc-policy-playground/src/app/app.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Component } from '@angular/core';
 

--- a/edc-policy-playground/src/app/app.module.ts
+++ b/edc-policy-playground/src/app/app.module.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';

--- a/edc-policy-playground/src/app/components/editor/editor.component.html
+++ b/edc-policy-playground/src/app/components/editor/editor.component.html
@@ -1,13 +1,19 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->

--- a/edc-policy-playground/src/app/components/editor/editor.component.ts
+++ b/edc-policy-playground/src/app/components/editor/editor.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { AfterViewInit, Component, Output, ViewChild, ElementRef, ViewEncapsulation, Input } from '@angular/core';
 import { EditorView, basicSetup } from 'codemirror';

--- a/edc-policy-playground/src/app/components/header/header.component.css
+++ b/edc-policy-playground/src/app/components/header/header.component.css
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 .header {
   box-shadow:

--- a/edc-policy-playground/src/app/components/header/header.component.html
+++ b/edc-policy-playground/src/app/components/header/header.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <mat-toolbar color="primary" class="header">

--- a/edc-policy-playground/src/app/components/header/header.component.ts
+++ b/edc-policy-playground/src/app/components/header/header.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Component } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/atomic.constraint.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/atomic.constraint.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <div class="flex flex-col">

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/atomic.constraint.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/atomic.constraint.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgFor, NgSwitch, NgSwitchCase } from '@angular/common';
 import { Component, Input } from '@angular/core';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/constraint.list.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/constraint.list.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <mat-list>

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/constraint.list.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/constraint.list.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgFor } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/value.expression.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/value.expression.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <div class="w-full" *ngIf="value">

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/value.expression.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/constraint/value.expression.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgFor, NgIf, NgSwitch, NgSwitchCase } from '@angular/common';
 import { Component, Input, OnInit } from '@angular/core';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/constraint-dialog.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/constraint-dialog.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <h1 mat-dialog-title>Edit Constraint</h1>

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/constraint-dialog.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/constraint-dialog.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgFor } from '@angular/common';
 import { Component, Inject } from '@angular/core';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/logical-dialog/logical-dialog.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/logical-dialog/logical-dialog.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <h1 mat-dialog-title>Edit Logical Constraint</h1>

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/logical-dialog/logical-dialog.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/dialog/logical-dialog/logical-dialog.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { NgFor, NgIf } from '@angular/common';
 import { Component, Inject } from '@angular/core';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/permission.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/permission.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <mat-card class="grow">

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/permission.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/permission/permission.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AtomicConstraint, Constraint, ConstraintTemplate, LogicalConstraint, Permission } from 'src/app/models/policy';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.css
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.css
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 .policy-builder-container {
   display: flex;

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <div class="policy-builder-container">

--- a/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-builder/policy-builder.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.css
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.css
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 .policy-editor {
   height: 100%;

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.html
@@ -1,15 +1,21 @@
 <!--
-  ~  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-  ~
-  ~  This program and the accompanying materials are made available under the
-  ~  terms of the Apache License, Version 2.0 which is available at
-  ~  https://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~  SPDX-License-Identifier: Apache-2.0
-  ~
-  ~  Contributors:
-  ~       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
-  ~
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
   -->
 
 <div class="policy-editor-container">

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Component } from '@angular/core';
 import { EditorComponent } from '../editor/editor.component';

--- a/edc-policy-playground/src/app/models/policy.ts
+++ b/edc-policy-playground/src/app/models/policy.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 export class Permission {
   name?: string;

--- a/edc-policy-playground/src/app/services/constraints.ts
+++ b/edc-policy-playground/src/app/services/constraints.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { AtomicConstraint, LogicalConstraint, Operator, Value, ValueKind } from '../models/policy';
 

--- a/edc-policy-playground/src/app/services/format.service.ts
+++ b/edc-policy-playground/src/app/services/format.service.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 /*eslint-disable @typescript-eslint/no-explicit-any*/
 

--- a/edc-policy-playground/src/app/services/policy.service.ts
+++ b/edc-policy-playground/src/app/services/policy.service.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Injectable } from '@angular/core';
 import {

--- a/edc-policy-playground/src/app/stores/policy.store.ts
+++ b/edc-policy-playground/src/app/stores/policy.store.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { Injectable } from '@angular/core';
 import { Constraint, Permission, PolicyConfiguration } from '../models/policy';

--- a/edc-policy-playground/src/index.html
+++ b/edc-policy-playground/src/index.html
@@ -1,3 +1,23 @@
+<!--
+  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+  Copyright (c) 2023 Contributors to the Eclipse Foundation
+
+  See the NOTICE file(s) distributed with this work for additional
+  information regarding copyright ownership.
+
+  This program and the accompanying materials are made available under the
+  terms of the Apache License, Version 2.0 which is available at
+  https://www.apache.org/licenses/LICENSE-2.0.
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+
+  SPDX-License-Identifier: Apache-2.0
+  -->
+
 <!doctype html>
 <html lang="en">
   <head>

--- a/edc-policy-playground/src/main.ts
+++ b/edc-policy-playground/src/main.ts
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 

--- a/edc-policy-playground/src/styles.css
+++ b/edc-policy-playground/src/styles.css
@@ -1,16 +1,22 @@
-/*
- *  Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
  *
- *  This program and the accompanying materials are made available under the
- *  terms of the Apache License, Version 2.0 which is available at
- *  https://www.apache.org/licenses/LICENSE-2.0
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
  *
- *  SPDX-License-Identifier: Apache-2.0
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
  *
- *  Contributors:
- *       Bayerische Motoren Werke Aktiengesellschaft (BMW AG) - initial API and implementation
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
- */
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
 
 /* You can add global styles to this file, and also import other style files */
 

--- a/mxd/ingress.tf
+++ b/mxd/ingress.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
     name = "mxd-ingress"

--- a/mxd/keycloak-realm.tf
+++ b/mxd/keycloak-realm.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_config_map" "keycloak-realm" {
   metadata {
     name = "keycloak-realm"

--- a/mxd/keycloak.tf
+++ b/mxd/keycloak.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_deployment" "keycloak" {
   metadata {
     name = "keycloak"

--- a/mxd/main.tf
+++ b/mxd/main.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 terraform {
   required_providers {
     helm = {

--- a/mxd/miw.tf
+++ b/mxd/miw.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_deployment" "miw" {
   metadata {
     name = "miw"

--- a/mxd/modules/connector/ingress.tf
+++ b/mxd/modules/connector/ingress.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_ingress_v1" "mxd-ingress" {
   metadata {
     name = "${var.participantId}-ingress"

--- a/mxd/modules/connector/main.tf
+++ b/mxd/modules/connector/main.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "helm_release" "connector" {
   name              = lower(var.participantId)
   force_update      = true

--- a/mxd/modules/connector/nodeport.tf
+++ b/mxd/modules/connector/nodeport.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 # technically, the Helm chart for the connector already brings a Kubernetes service, but there is no
 # (easy) way to get ahold of it from terraform, so lets just declare another one
 

--- a/mxd/modules/connector/outputs.tf
+++ b/mxd/modules/connector/outputs.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 output "aes_key" {
   value = local.aes_key_b64
 }

--- a/mxd/modules/connector/variables.tf
+++ b/mxd/modules/connector/variables.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 variable "image-pull-policy" {
   default     = "Always"
   type        = string

--- a/mxd/outputs.tf
+++ b/mxd/outputs.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 output "connector1-aeskey" {
   value = module.alice-connector.aes_key
 }

--- a/mxd/postgres.tf
+++ b/mxd/postgres.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 resource "kubernetes_deployment" "postgres" {
   metadata {
     name = "postgres"

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 # This job's purpose is to supply some very basic master data to both connectors.
 # It will each create two assets, a policy and two contract definitions.
 # To achieve that, the Job mounts a Postman collection as ConfigMap, and runs it using newman

--- a/mxd/variables.tf
+++ b/mxd/variables.tf
@@ -1,3 +1,22 @@
+#
+#  Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#
+
 # configuration values for the MIW+Keycloak Postgres db
 variable "keycloak-database" {
   default = "keycloak"


### PR DESCRIPTION
Fix license headers on ts/html/css files

Please ensure to do as many of the following checks as possible, before asking for committer review:


Closes: #21

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
