### PR TITLE
feat(playground) supports plain and prefix formats

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -376,7 +376,7 @@ npm/npmjs/-/istanbul-reports/3.1.6, BSD-3-Clause AND MIT, approved, #1710
 npm/npmjs/-/jackspeak/2.2.2, BlueOak-1.0.0, approved, #8268
 npm/npmjs/-/jake/10.8.7, Apache-2.0 AND MIT, approved, #1316
 npm/npmjs/-/jasmine-core/4.6.0, MIT, approved, clearlydefined
-npm/npmjs/-/jasmine-core/5.1.0, , restricted, clearlydefined
+npm/npmjs/-/jasmine-core/5.1.0, MIT, approved, clearlydefined
 npm/npmjs/-/jest-worker/27.5.1, 0BSD AND Apache-2.0 AND BSD-2-Clause AND MIT, approved, #1952
 npm/npmjs/-/jiti/1.19.1, MIT, approved, #9437
 npm/npmjs/-/js-tokens/4.0.0, MIT, approved, #2401
@@ -555,7 +555,7 @@ npm/npmjs/-/postcss-value-parser/4.2.0, MIT, approved, clearlydefined
 npm/npmjs/-/postcss/8.4.27, MIT, approved, #3545
 npm/npmjs/-/prelude-ls/1.2.1, MIT, approved, clearlydefined
 npm/npmjs/-/prettier-linter-helpers/1.0.0, MIT, approved, clearlydefined
-npm/npmjs/-/prettier/3.0.1, MIT, restricted, clearlydefined
+npm/npmjs/-/prettier/3.0.1, MIT AND (BSD-2-Clause AND ISC AND MIT) AND MPL-1.0, restricted, #10095
 npm/npmjs/-/pretty-bytes/5.6.0, MIT, approved, clearlydefined
 npm/npmjs/-/proc-log/3.0.0, ISC, approved, clearlydefined
 npm/npmjs/-/process-nextick-args/2.0.1, MIT, approved, clearlydefined
@@ -601,7 +601,7 @@ npm/npmjs/-/retry/0.13.1, MIT, approved, clearlydefined
 npm/npmjs/-/reusify/1.0.4, MIT, approved, clearlydefined
 npm/npmjs/-/rfdc/1.3.0, MIT, approved, clearlydefined
 npm/npmjs/-/rimraf/3.0.2, ISC, approved, clearlydefined
-npm/npmjs/-/rollup/3.27.0, , restricted, clearlydefined
+npm/npmjs/-/rollup/3.27.0, MIT, approved, clearlydefined
 npm/npmjs/-/run-applescript/5.0.0, MIT, approved, clearlydefined
 npm/npmjs/-/run-async/2.4.1, MIT, approved, clearlydefined
 npm/npmjs/-/run-parallel/1.2.0, MIT, approved, clearlydefined
@@ -792,11 +792,11 @@ npm/npmjs/@angular-devkit/build-angular/16.2.0, , restricted, clearlydefined
 npm/npmjs/@angular-devkit/build-webpack/0.1602.0, , restricted, clearlydefined
 npm/npmjs/@angular-devkit/core/16.2.0, , restricted, clearlydefined
 npm/npmjs/@angular-devkit/schematics/16.2.0, , restricted, clearlydefined
-npm/npmjs/@angular-eslint/builder/16.1.0, , restricted, clearlydefined
+npm/npmjs/@angular-eslint/builder/16.1.0, MIT, restricted, clearlydefined
 npm/npmjs/@angular-eslint/bundled-angular-compiler/16.1.0, MIT, approved, clearlydefined
-npm/npmjs/@angular-eslint/eslint-plugin-template/16.1.0, , restricted, clearlydefined
+npm/npmjs/@angular-eslint/eslint-plugin-template/16.1.0, MIT, approved, clearlydefined
 npm/npmjs/@angular-eslint/eslint-plugin/16.1.0, MIT, approved, clearlydefined
-npm/npmjs/@angular-eslint/schematics/16.1.0, , restricted, clearlydefined
+npm/npmjs/@angular-eslint/schematics/16.1.0, MIT, approved, clearlydefined
 npm/npmjs/@angular-eslint/template-parser/16.1.0, MIT, approved, clearlydefined
 npm/npmjs/@angular-eslint/utils/16.1.0, MIT, approved, clearlydefined
 npm/npmjs/@angular/animations/16.2.0, , restricted, clearlydefined

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.css
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.css
@@ -36,7 +36,6 @@
 .policy-card-container {
   height: 100%;
   border-radius: 4px;
-  margin: 24px 0;
   border: 1px solid rgba(0, 0, 0, 0.2);
 }
 

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.html
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.html
@@ -36,6 +36,16 @@
       <mat-icon>content_copy</mat-icon>
     </button>
   </div>
+  <div class="flex justify-right">
+    <mat-form-field appearance="outline">
+      <mat-label>Output format</mat-label>
+      <mat-select [ngModel]="currentFormat" (ngModelChange)="onOutputFormatChange($event)">
+        <mat-option *ngFor="let format of outputFormats" [value]="format">
+          {{ format }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
   <div class="flex flex-row policy-split-container">
     <div class="policy-card-container w-3/5">
       <app-policy-builder (policyChange)="onConfigChange($event)" [policyConfig]="policyConfig"></app-policy-builder>

--- a/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.ts
+++ b/edc-policy-playground/src/app/components/policy-editor/policy-editor.component.ts
@@ -27,12 +27,13 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
-import { PolicyConfiguration } from 'src/app/models/policy';
+import { OutputKind, PolicyConfiguration } from 'src/app/models/policy';
 import { FormsModule } from '@angular/forms';
 import { NgFor } from '@angular/common';
 import { FormatService } from 'src/app/services/format.service';
 import { PolicyConfigurationStore } from 'src/app/stores/policy.store';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { PolicyService } from 'src/app/services/policy.service';
 
 @Component({
   selector: 'app-policy-editor',
@@ -56,22 +57,28 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 export class PolicyEditorComponent {
   text!: string;
 
+  outputFormats: string[];
   policyConfig: PolicyConfiguration;
+
+  currentFormat: OutputKind;
 
   configurations: PolicyConfiguration[] = [];
 
   constructor(
     public formatService: FormatService,
     public store: PolicyConfigurationStore,
+    public policyService: PolicyService,
   ) {
     this.configurations = store.loadConfigurations();
+    this.currentFormat = OutputKind.Plain;
 
     if (this.configurations.length == 0) {
       store.store(new PolicyConfiguration('Policy Template'));
     }
     this.policyConfig = this.configurations[0];
+    this.outputFormats = policyService.supportedOutput();
 
-    this.updateJsonText(this.policyConfig);
+    this.updateJsonText(this.policyConfig, this.currentFormat);
   }
 
   addPolicy(): void {
@@ -86,14 +93,18 @@ export class PolicyEditorComponent {
 
   onConfigSelectionChange(cfg: PolicyConfiguration) {
     this.policyConfig = cfg;
-    this.updateJsonText(cfg);
+    this.updateJsonText(cfg, this.currentFormat);
   }
   onConfigChange(cfg: PolicyConfiguration) {
-    this.updateJsonText(cfg);
+    this.updateJsonText(cfg, this.currentFormat);
   }
 
-  updateJsonText(cfg: PolicyConfiguration) {
-    const ld = this.formatService.toJsonLd(cfg);
+  onOutputFormatChange(format: OutputKind) {
+    this.updateJsonText(this.policyConfig, format);
+  }
+
+  updateJsonText(cfg: PolicyConfiguration, format: OutputKind) {
+    const ld = this.formatService.toJsonLd(cfg, format);
     this.text = this.formatService.formatPolicy(ld);
   }
 }

--- a/edc-policy-playground/src/app/models/policy.ts
+++ b/edc-policy-playground/src/app/models/policy.ts
@@ -180,3 +180,8 @@ export interface ConstraintTemplate {
 }
 
 export type RightOperand = string | number | Value;
+
+export enum OutputKind {
+  Prefixed = 'Prefixed',
+  Plain = 'Plain',
+}

--- a/edc-policy-playground/src/app/services/format/plain.ts
+++ b/edc-policy-playground/src/app/services/format/plain.ts
@@ -1,0 +1,100 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
+import {
+  AtomicConstraint,
+  Constraint,
+  LogicalConstraint,
+  Permission,
+  PolicyConfiguration,
+  Value,
+} from 'src/app/models/policy';
+import { JsonLdFormatter } from '../format.service';
+
+export const policyRequestTemplate = {
+  '@context': {
+    edc: 'https://w3id.org/edc/v0.0.1/ns/',
+  },
+  '@type': 'PolicyDefinitionRequest',
+  '@id': '{{POLICY_ID}}',
+  policy: {},
+};
+
+const policyHeader = {
+  '@type': 'Set',
+  '@context': 'http://www.w3.org/ns/odrl.jsonld',
+};
+
+export const emptyPolicy = Object.assign(policyRequestTemplate, {
+  policy: {
+    ...policyHeader,
+    permission: [],
+  },
+});
+
+export class PlainFormatter implements JsonLdFormatter {
+  toJsonLd(policyConfig: PolicyConfiguration): object {
+    const permission = policyConfig.policy.permissions.map(this.mapPermission.bind(this));
+
+    return Object.assign(emptyPolicy, {
+      policy: { ...policyHeader, permission },
+    });
+  }
+
+  mapPermission(permission: Permission): object {
+    return {
+      action: permission.action.toString(),
+      constraint: permission.constraints.map(this.mapConstraint.bind(this)),
+    };
+  }
+
+  mapConstraint(constraint: Constraint): object {
+    if (constraint instanceof AtomicConstraint) {
+      return {
+        leftOperand: {
+          '@value': constraint.leftOperand,
+        },
+        operator: constraint.operator.toString(),
+        rightOperand: this.mapRightOperand(constraint),
+      };
+    } else if (constraint instanceof LogicalConstraint) {
+      const obj: any = {
+        '@type': 'LogicalConstraint',
+      };
+      obj[constraint.operator.toString().toLowerCase()] = constraint.constraints.map(this.mapConstraint.bind(this));
+      return obj;
+    }
+
+    return {};
+  }
+
+  mapRightOperand(constraint: AtomicConstraint): string | number | object | undefined {
+    if (constraint.rightOperand instanceof Value) {
+      return {
+        '@value': constraint.rightOperand.value,
+        '@type': constraint.rightOperand.ty,
+      };
+    } else {
+      return constraint.rightOperand;
+    }
+  }
+}

--- a/edc-policy-playground/src/app/services/format/prefix.ts
+++ b/edc-policy-playground/src/app/services/format/prefix.ts
@@ -1,0 +1,102 @@
+/*******************************************************************************
+ * Copyright (c) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+ * Copyright (c) 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+/*eslint-disable @typescript-eslint/no-explicit-any*/
+
+import {
+  AtomicConstraint,
+  Constraint,
+  LogicalConstraint,
+  Permission,
+  PolicyConfiguration,
+  Value,
+} from 'src/app/models/policy';
+import { JsonLdFormatter } from '../format.service';
+
+export const policyRequestTemplate = {
+  '@context': {
+    edc: 'https://w3id.org/edc/v0.0.1/ns/',
+    odrl: 'http://www.w3.org/ns/odrl/2/',
+  },
+  '@type': 'PolicyDefinitionRequest',
+  '@id': '{{POLICY_ID}}',
+  policy: {},
+};
+
+const policyHeader = {
+  '@type': 'odrl:Set',
+};
+
+export const emptyPolicy = Object.assign(policyRequestTemplate, {
+  policy: {
+    ...policyHeader,
+    'odrl:permission': [],
+  },
+});
+
+export class PrefixFormatter implements JsonLdFormatter {
+  toJsonLd(policyConfig: PolicyConfiguration): object {
+    const permission = policyConfig.policy.permissions.map(this.mapPermission.bind(this));
+
+    return Object.assign(emptyPolicy, {
+      policy: { ...policyHeader, 'odrl:permission': permission },
+    });
+  }
+
+  mapPermission(permission: Permission): object {
+    return {
+      'odrl:action': permission.action.toString(),
+      'odrl:constraint': permission.constraints.map(this.mapConstraint.bind(this)),
+    };
+  }
+
+  mapConstraint(constraint: Constraint): object {
+    if (constraint instanceof AtomicConstraint) {
+      return {
+        'odrl:leftOperand': constraint.leftOperand,
+        'odrl:operator': {
+          '@id': 'odrl:' + constraint.operator.toString(),
+        },
+        'odlr:rightOperand': this.mapRightOperand(constraint),
+      };
+    } else if (constraint instanceof LogicalConstraint) {
+      const obj: any = {
+        '@type': 'odrl:LogicalConstraint',
+      };
+      obj['odlr:' + constraint.operator.toString().toLowerCase()] = constraint.constraints.map(
+        this.mapConstraint.bind(this),
+      );
+      return obj;
+    }
+
+    return {};
+  }
+
+  mapRightOperand(constraint: AtomicConstraint): string | number | object | undefined {
+    if (constraint.rightOperand instanceof Value) {
+      return {
+        '@value': constraint.rightOperand.value,
+        '@type': constraint.rightOperand.ty,
+      };
+    } else {
+      return constraint.rightOperand;
+    }
+  }
+}

--- a/edc-policy-playground/src/app/services/policy.service.ts
+++ b/edc-policy-playground/src/app/services/policy.service.ts
@@ -26,6 +26,7 @@ import {
   LogicalConstraint,
   LogicalOperator,
   Operator,
+  OutputKind,
   ValueKind,
 } from '../models/policy';
 import {
@@ -51,6 +52,10 @@ export class PolicyService {
 
   actions(): string[] {
     return this.values(Action);
+  }
+
+  supportedOutput(): string[] {
+    return this.values(OutputKind);
   }
 
   private values(val: object): string[] {

--- a/edc-policy-playground/src/styles.css
+++ b/edc-policy-playground/src/styles.css
@@ -58,6 +58,9 @@ body {
 .justify-center {
   justify-content: center;
 }
+.justify-right {
+  justify-content: right;
+}
 
 .grow {
   flex-grow: 1;


### PR DESCRIPTION
In this PR add a select for choosing the preferred output for the policy in JSON-LD

it can: 

- plain (without usage of 
- prefix (eg. odrl: )

