### PR TITLE
fix: add correct BPN number to the seeded policy

### DIFF
--- a/mxd/postman/mxd-seed.json
+++ b/mxd/postman/mxd-seed.json
@@ -298,7 +298,7 @@
     },
     {
       "key": "POLICY_BPN",
-      "value": "BPNBOB",
+      "value": "BPNL000000000000",
       "type": "default"
     },
     {

--- a/mxd/seed_data.tf
+++ b/mxd/seed_data.tf
@@ -46,7 +46,7 @@ resource "kubernetes_job" "seed_connectors_via_mgmt_api" {
             "newman", "run",
             "--folder", "SeedData",
             "--env-var", "MANAGEMENT_URL=http://${module.bob-connector.node-ip}:8081/management/v2",
-            "--env-var", "POLICY_BPN=BPNALICE",
+            "--env-var", "POLICY_BPN=BPNL000000000000",
             "/opt/collection/${local.newman_collection_name}"
           ]
           volume_mount {


### PR DESCRIPTION
Change the BPN to `BPNL000000000000` for seed policy and postman collection variable


- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
