### PR TITLE
chore: use latest MIW image

### DIFF
--- a/mxd/miw.tf
+++ b/mxd/miw.tf
@@ -41,7 +41,7 @@ resource "kubernetes_deployment" "miw" {
       spec {
         container {
           name              = "miw"
-          image             = "ghcr.io/catenax-ng/tx-managed-identity-wallets_miw_service:latest-java-did-web"
+          image             = "tractusx/managed-identity-wallet:main"
           image_pull_policy = "Always"
 
           port {


### PR DESCRIPTION
## Description
Uses the latest MIW docker image in MXD. This is necessary, because a recent PR in Tractus-X EDC upgraded as well, and those two are incompatible.

Related: https://github.com/eclipse-tractusx/tractusx-edc/pull/731

Closes #41 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
