### PR TITLE
feat: Enable Readiness / Liveness Probe for Keycloak

### DIFF
--- a/mxd/keycloak.tf
+++ b/mxd/keycloak.tf
@@ -68,6 +68,28 @@ resource "kubernetes_deployment" "keycloak" {
           #              memory = "50Mi"
           #            }
           #          }
+          readiness_probe {
+            http_get {
+              path = "/health/ready"
+              port = var.keycloak-port
+            }
+            initial_delay_seconds = 30
+            period_seconds        = 10
+            timeout_seconds       = 5
+            failure_threshold     = 10
+            success_threshold     = 1
+          }
+          liveness_probe {
+            http_get {
+              path = "/health/live"
+              port = var.keycloak-port
+            }
+            initial_delay_seconds = 30
+            period_seconds        = 10
+            timeout_seconds       = 5
+            failure_threshold     = 10
+            success_threshold     = 1
+          }
         }
         volume {
           name = "miw-test-realm"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Enable readiness / liveness probe for keycloak deployment.
Further dependent deployments should proceed only once keycloak is ready to serve traffic.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Closes #49 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
