### PR TITLE
chore: enable debug in dataplane

### DIFF
--- a/mxd/modules/connector/values.yaml
+++ b/mxd/modules/connector/values.yaml
@@ -47,6 +47,9 @@ controlplane:
       client:
         secretAlias: "client-secret"
 dataplane:
+  debug:
+    enabled: true
+    port: 1044
   image:
     pullPolicy: Never
     tag: "latest"
@@ -58,6 +61,10 @@ dataplane:
     endpointOverride: http://minio:9000
     secretAccessKey: qwerty123
     accessKeyId: qwerty123
+
+  env:
+    "EDC_API_AUTH_KEY" : "password"
+
 postgresql:
    # JDBC URL should be set from `main.tf`
    jdbcUrl:


### PR DESCRIPTION


## Description

This PR enable the debug in the dataplane and also add the `EDC_API_AUTH_KEY` configuration in the dataplane as env, since the value config it's not present in 0.5.1 [#735](https://github.com/eclipse-tractusx/tractusx-edc/pull/735)