### PR TITLE
docs: adds EDR section

### DIFF
--- a/mxd/README.md
+++ b/mxd/README.md
@@ -248,7 +248,7 @@ the "simple-asset" from [step 3.1](#31-add-a-basic-asset-policy-and-contract-def
 
 We can fetch Alice's catalog with this `curl` command:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/management/v2/catalog/request' --header 'Content-Type: application/json' --header 'X-Api-Key: password' \
 --data-raw '{
     "@context": {
@@ -271,7 +271,7 @@ More information about the catalog [here](https://eclipse-edc.github.io/docs/#/d
 
 The catalog response will look like this:
 
-``` json
+```json
 {
     "@id": "736199e5-5b9e-4944-8568-46af97bde862",
     "@type": "dcat:Catalog",
@@ -375,7 +375,7 @@ for us, and it will store it locally for future usage. The API for starting a ne
 
 We can start a new EDR negotiation with this `curl` command:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/management/edrs' \
 --header 'Content-Type: application/json' \
 --header 'X-Api-Key: password' \
@@ -401,9 +401,7 @@ curl --location 'http://localhost/bob/management/edrs' \
 				"odrl:constraint": {
 					"odrl:or": {
 						"odrl:leftOperand": "BusinessPartnerNumber",
-						"odrl:operator": {
-              "@id": "odrl:eq"
-            },
+						"odrl:operator": { "@id": "odrl:eq" },
 						"odrl:rightOperand": "BPNL000000000002"
 					}
 				}
@@ -424,7 +422,7 @@ For requesting an EDR we have to specify:
 
 If everithing is ok, we'll get this as response:
 
-``` json
+```json
 {
   "@type": "edc:IdResponse",
   "@id": "2f911118-657d-4001-b36c-73cb45222a4a",
@@ -447,7 +445,7 @@ In order to be notified without polling, we could configure the EDC callbacks fo
 
 We could for example add this in the original request:
 
-``` json
+```json
 {
   ...
   "callbackAddresses": [
@@ -466,13 +464,13 @@ and be notified when the transfer process transition to the state `STARTED` (EDR
 
 For having a list of the negotiatied EDR for the `assedId` `1` we can use this `curl` command:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/management/edrs?assetId=1' --header 'X-Api-Key: password' | jq
 ```
 
 and the response should look like this:
 
-``` json
+```json
 [
   {
     "@type": "tx:EndpointDataReferenceEntry",
@@ -497,14 +495,14 @@ and the response should look like this:
 To be able to fetch the data with only the `assetId` via consumer data plane proxy (see more later), only one
 `EndPointDataReferenceEntry` associated with an `assetId` should be valid (`Negotiated` or `Refreshing`) at one point in time.
 This will allow the proxy to fetch the right `EDR` while requesting data with the `assetId`. Alternatively if we negotiated multiple
-`EDRs` for the same `assetId` for some reason, we should use the `transferprocessid` for transferring the data.
+`EDRs` for the same `assetId` for some reason, we should use the `transferprocessId` for transferring the data.
 
 The renewal of the token is automatically handled by the `EDR` extension, we just need to fire the first EDR negotiation
 and start fetching the data.
 
 Since the EDR is renewed automatically, it can happen that while fetching the EDRs for a particular `assetId` we can see multiple entries like this:
 
-``` json
+```json
 [
   {
     "@type": "tx:EndpointDataReferenceEntry",
@@ -547,7 +545,7 @@ which means that the second `EDR` is now expired and marked for removal later in
 
 The EDR itself is stored in the configured vault. To retrieve it we can use this `curl` command:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/management/edrs/ff468685-0f9b-49a1-8ec6-ea40d5a2dc88' --header 'X-Api-Key: password' | jq
 ```
 
@@ -556,7 +554,7 @@ and the automatic EDR renewal process will just fire another transfer request wi
 
 The response will look like this:
 
-``` json
+```json
 {
   "@type": "edc:DataAddress",
   "edc:type": "EDR",
@@ -586,14 +584,14 @@ For fetching the data we can use two strategies depending on the use case:
 
 Once the right EDR has been identified using the EDR management API, we can use the `endpont`, `authCode` and `authKey` to make the data request:
 
-``` shell
+```shell
 curl --location 'http://localhost/alice/api/public' \
 --header 'Authorization: eyJhbGciOiJFUzI1NiJ9.eyJleHAiOjE2OTQ1MjIwNTksImRhZCI6ImNoTTlvVTVLNXQzbDlWMFRsL1ZZdDlLU1J4YmNOSUdzM1FtazNlNktWOWpWcTBkeUhjUDU2Mm82Qk0zSitxeTRwRVg2d0EvWUFsdW9EdGptYnYxZlJoN3VmVmsvQjNONzhBMUhyZ01ENnk2enFsK1BEYzBXa00yTm9ycUJWQUl0TWpVNEFNbGhFMXE1Ym9EQ1lWcVRsQVZnbm9uTlB5MmlVUzVSVTJHTkZtOWFkZVZYR1ZLaDFDWEMzVDV0RkRCS21EMjExWVZYdDExRUlXbCtIU3VISm1PL0xwUUdibFkvaGFicXZ6aUZ0YlppbGlKSDNLdGVhZTZQRkdQTjNWT1Z4YlFrZTNmODNRN3VNeStBNzV4YS9VR1BMcjJlQkJzb0ZVbTBYeFFJS2dBOUROdGxXcnBuR3hwdG9tL1VWY00wQ1RwcWM5eFRRdGlnK3JMVlJ4dUhrb2RreG5KUXhiSENVMnNObnFhdXZJcDV4L04rbGdJN0F1amhtQWxiN2NwUWs0RDhSWWtZSnkvVUZGdGZmZUJLU2k2MnZDeC9QSFJsSERlUGM4VldDaEJTNFF1Q1FXY1pOK2oyUjR5b2Q2a3JlN2JtUStFK3pLUmYva3JhQkJkR041TDR5ZVdIYU0wS3oraGxiSVR5WHg2bjdrQ0VkVVVSREtCUHY3SHdzbHhLTzlxN05ReHplMHFDM0phR2pyWVdHZmJHTzB4SDlJRndsSWpqclZHMzE0WUVxNGdSTjNNPSIsImNpZCI6Ik1RPT06TVE9PTpOV0ZqTTJJeVkyWXRNRGt4WkMwME9UQmxMV0poTXpNdE1ERmxNRGhtTUdNNU5tVTIifQ.2UT3_mIjchrC242TqlLFWoyYPiCOPLLivaN5Xd4_MxhcQkxRkOxrK0IXkXVuRVjC1ReGPi3iaco9LDUxvF3FPw' | jq
 ```
 
 and the response will look like this:
 
-``` json
+```json
 [
     {
         "userId": 1,
@@ -631,7 +629,7 @@ that EDR will be automatically renewed.
 
 We can simply use the `proxy` API for fetching the data with a `POST` request:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/proxy/aas/request' \
 --header 'Content-Type: application/json' \
 --header 'X-Api-Key: password' \
@@ -643,7 +641,7 @@ curl --location 'http://localhost/bob/proxy/aas/request' \
 
 and get the same results as the provider data-plane option:
 
-``` json
+```json
 [
     {
         "userId": 1,
@@ -675,7 +673,7 @@ do a `GET` request to the provider data-plane for us.
 Since the `DataAddress` of the asset has been configured to proxy also `pathSegments`, we could add another
 parameter in the request to fetch exactly one item from the list:
 
-``` shell
+```shell
 curl --location 'http://localhost/bob/proxy/aas/request' \
 --header 'Content-Type: application/json' \
 --header 'X-Api-Key: password' \
@@ -688,7 +686,7 @@ curl --location 'http://localhost/bob/proxy/aas/request' \
 
 which will give us:
 
-``` json
+```json
 {
   "userId": 1,
   "id": 1,

--- a/mxd/modules/connector/ingress.tf
+++ b/mxd/modules/connector/ingress.tf
@@ -51,6 +51,28 @@ resource "kubernetes_ingress_v1" "mxd-ingress" {
             }
           }
         }
+        path {
+          path = "/${var.humanReadableName}(/|$)(proxy/.*)"
+          backend {
+            service {
+              name = local.data-plane-service
+              port {
+                number = 8186
+              }
+            }
+          }
+        }
+        path {
+          path = "/${var.humanReadableName}(/|$)(api/public.*)"
+          backend {
+            service {
+              name = local.data-plane-service
+              port {
+                number = 8081
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -58,6 +80,8 @@ resource "kubernetes_ingress_v1" "mxd-ingress" {
 
 locals {
   control-plane-service = "${var.humanReadableName}-tractusx-connector-controlplane"
+  data-plane-service    = "${var.humanReadableName}-tractusx-connector-dataplane"
   management_url        = "http://localhost/${var.humanReadableName}/management/v2"
+  proxy_url             = "http://localhost/${var.humanReadableName}/proxy"
   health_url            = "http://localhost/${var.humanReadableName}/health"
 }

--- a/mxd/modules/connector/ingress.tf
+++ b/mxd/modules/connector/ingress.tf
@@ -84,4 +84,5 @@ locals {
   management_url        = "http://localhost/${var.humanReadableName}/management/v2"
   proxy_url             = "http://localhost/${var.humanReadableName}/proxy"
   health_url            = "http://localhost/${var.humanReadableName}/health"
+  public_url            = "http://localhost/${var.humanReadableName}/api/public"
 }

--- a/mxd/modules/connector/outputs.tf
+++ b/mxd/modules/connector/outputs.tf
@@ -33,6 +33,7 @@ output "urls" {
     management = local.management_url
     health     = local.health_url
     proxy      = local.proxy_url
+    public     = local.public_url
   }
 }
 

--- a/mxd/modules/connector/outputs.tf
+++ b/mxd/modules/connector/outputs.tf
@@ -32,6 +32,7 @@ output "urls" {
   value = {
     management = local.management_url
     health     = local.health_url
+    proxy     =  local.proxy_url
   }
 }
 output "node-ip" {

--- a/mxd/modules/connector/outputs.tf
+++ b/mxd/modules/connector/outputs.tf
@@ -32,9 +32,10 @@ output "urls" {
   value = {
     management = local.management_url
     health     = local.health_url
-    proxy     =  local.proxy_url
+    proxy      = local.proxy_url
   }
 }
+
 output "node-ip" {
   value = kubernetes_service.controlplane-service.spec.0.cluster_ip
 }

--- a/mxd/postman/mxd-management-apis.json
+++ b/mxd/postman/mxd-management-apis.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "294c5d0c-6677-4eb5-9f87-48596666b666",
+		"_postman_id": "54c1f694-b885-4b7d-b069-5d394be398fa",
 		"name": "tractusx-edc-mgmt-api",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "27652630"
@@ -524,7 +524,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"connectorAddress\": \"{{PROVIDER_PROTOCOL_URL}}\",\n    \"connectorId\": \"{{PROVIDER_ID}}\",\n    \"contractId\": \"MQ==:MQ==:OGIxZmY5ODgtMzIwMy00OWY5LWFjMjMtN2RmN2JiYjQ1NzQx\",\n    \"dataDestination\": {\n        \"type\": \"HttpProxy\"\n    },\n    \"privateProperties\": {\n        \"receiverHttpEndpoint\": \"{{BACKEND_SERVICE}}\"\n    },\n    \"protocol\": \"dataspace-protocol-http\",\n    \"transferType\": {\n        \"contentType\": \"application/octet-stream\",\n        \"isFinite\": true\n    }\n}",
+					"raw": "{\n    \"@context\": {\n        \"odrl\": \"http://www.w3.org/ns/odrl/2/\"\n    },\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"connectorAddress\": \"{{PROVIDER_PROTOCOL_URL}}\",\n    \"connectorId\": \"{{PROVIDER_ID}}\",\n    \"contractId\": \"<contractAgreementId>\",\n    \"dataDestination\": {\n        \"type\": \"HttpProxy\"\n    },\n    \"privateProperties\": {\n        \"receiverHttpEndpoint\": \"{{BACKEND_SERVICE}}\"\n    },\n    \"protocol\": \"dataspace-protocol-http\",\n    \"transferType\": {\n        \"contentType\": \"application/octet-stream\",\n        \"isFinite\": true\n    }\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -650,7 +650,9 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"exec": [],
+						"exec": [
+							""
+						],
 						"type": "text/javascript"
 					}
 				}
@@ -668,12 +670,11 @@
 					}
 				},
 				"url": {
-					"raw": "{{CONSUMER_ADAPTER_URL}}/v2/edrs",
+					"raw": "{{CONSUMER_MANAGEMENT_URL}}/edrs",
 					"host": [
-						"{{CONSUMER_ADAPTER_URL}}"
+						"{{CONSUMER_MANAGEMENT_URL}}"
 					],
 					"path": [
-						"v2",
 						"edrs"
 					]
 				}
@@ -699,7 +700,9 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"exec": [],
+						"exec": [
+							""
+						],
 						"type": "text/javascript"
 					}
 				}
@@ -720,12 +723,11 @@
 					}
 				},
 				"url": {
-					"raw": "{{CONSUMER_ADAPTER_URL}}/v2/edrs?assetId={{ASSET_ID}}",
+					"raw": "{{CONSUMER_MANAGEMENT_URL}}/edrs?assetId={{ASSET_ID}}",
 					"host": [
-						"{{CONSUMER_ADAPTER_URL}}"
+						"{{CONSUMER_MANAGEMENT_URL}}"
 					],
 					"path": [
-						"v2",
 						"edrs"
 					],
 					"query": [
@@ -757,7 +759,9 @@
 				{
 					"listen": "prerequest",
 					"script": {
-						"exec": [],
+						"exec": [
+							""
+						],
 						"type": "text/javascript"
 					}
 				}
@@ -778,12 +782,11 @@
 					}
 				},
 				"url": {
-					"raw": "{{CONSUMER_ADAPTER_URL}}/v2/edrs/e1e986be-3ac3-4166-8fa9-b44be00a37ba",
+					"raw": "{{CONSUMER_MANAGEMENT_URL}}/edrs/e1e986be-3ac3-4166-8fa9-b44be00a37ba",
 					"host": [
-						"{{CONSUMER_ADAPTER_URL}}"
+						"{{CONSUMER_MANAGEMENT_URL}}"
 					],
 					"path": [
-						"v2",
 						"edrs",
 						"e1e986be-3ac3-4166-8fa9-b44be00a37ba"
 					]
@@ -792,7 +795,58 @@
 			"response": []
 		},
 		{
-			"name": "Get Asset Data with proxy",
+			"name": "Del EDR by tp ID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				},
+				{
+					"listen": "prerequest",
+					"script": {
+						"exec": [
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_MANAGEMENT_URL}}/edrs/eb97391e-b30d-4da8-a5ff-8f865ac1d622",
+					"host": [
+						"{{CONSUMER_MANAGEMENT_URL}}"
+					],
+					"path": [
+						"edrs",
+						"eb97391e-b30d-4da8-a5ff-8f865ac1d622"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Data with proxy",
 			"event": [
 				{
 					"listen": "test",
@@ -813,7 +867,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"endpointUrl\": \"http://plato-dataplane:8080/api/gateway/aas/1\"\n}",
+					"raw": "{\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"providerId\": \"{{PROVIDER_ID}}\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -821,16 +875,102 @@
 					}
 				},
 				"url": {
-					"raw": "http://localhost:8186/proxy/aas/request",
-					"protocol": "http",
+					"raw": "{{CONSUMER_PROXY_URL}}/aas/request",
 					"host": [
-						"localhost"
+						"{{CONSUMER_PROXY_URL}}"
 					],
-					"port": "8186",
 					"path": [
-						"proxy",
 						"aas",
 						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Data with proxy  (PathSegments)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"assetId\": \"{{ASSET_ID}}\",\n    \"providerId\": \"{{PROVIDER_ID}}\",\n    \"pathSegments\": \"/1\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{CONSUMER_PROXY_URL}}/aas/request",
+					"host": [
+						"{{CONSUMER_PROXY_URL}}"
+					],
+					"path": [
+						"aas",
+						"request"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Data with provider dataplane",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Body matches string\", function () {",
+							"    var jsonData = pm.response.json();",
+							"    pm.collectionVariables.set(\"NEGOTIATION_ID\", jsonData.id);",
+							"",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "eyJhbGciOiJFUzI1NiJ9.eyJleHAiOjE2OTQ1MjMxNDcsImRhZCI6IkFLdHNGbnIyZy8vZytyMFZPak56ekM0RzVhd3VMeFBLTjNTUVJERHExU3ZUTUxuMjlRSk1YQUwyNmkyaitsNDZsSlNYbmlibVhJeldBT3RMVUhsOWw1dVdrajRyY1VRbzFidWdHdHpIeWFKenh4d2pZYlVIYms1NzRaWFhVMGlMaEE0N2MrbExaeXRubmEwVFFqVkJ2V21McjdkY0IxWGJRYVorNi9aZ1l4SExhWHdnYkhDRWNMcGE3WFh2RG9xY3V3VExyNDFOZ1pyRHkrY3lDT3BSZmRIbml6ZnRtS2cxYWxXL2RrdUtlK29FbUhQM1NGNEtaVi84YTNrTjAvREZMQXR2ZHhaYzFpVHhSQVY3enJtSU5jVmZCRjdqd3NtRk1hdU5GaW1YbktVNzB3OC9nUzlDazNQVlZ3NjU1czU1Tjk0RkF5R1ZGd3VDTXpFNGhLcGU2ZEFSbjdUWmJHbVBUdEt1OUg3VEV2L2VOT1E4RWhHQVNZWkNRSHlaTTZlbmg3Sld5Qm55UFFDOXZJR1dhcTFRTVdLUzJ6OXNpUEhVM0dnWElOSEhtN1lVdjREWXpybitJSEZYMzRGMWxWUzlzQ3ltMC9LTVdhdjY4ZHU2L0VjM2FqNlMzaFpNaXZNc3NGTEhHamNibHRYSVBoTFJvVEtER3V4ckJkdFZpYVpnemx3b1RpOTRkeTdYbFBZalR0RXo3VysxVE1XRjhPaFBSelNhT3BxYWMwdzRWUGJ0anVVPSIsImNpZCI6Ik1RPT06TVE9PTpOV0ZqTTJJeVkyWXRNRGt4WkMwME9UQmxMV0poTXpNdE1ERmxNRGhtTUdNNU5tVTIifQ.4VwEdEmmuHTObxYDAIn-C_mq-UKxxQWRMTD0Vi5L02WORRzga5TjlJp28_7-jcDufxN1j7S7AJRoNm5VWjGhZA",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{PROVIDER_PUBLIC_URL}}",
+					"host": [
+						"{{PROVIDER_PUBLIC_URL}}"
 					]
 				}
 			},
@@ -875,7 +1015,7 @@
 	"variable": [
 		{
 			"key": "CONSUMER_MANAGEMENT_URL",
-			"value": "http://localhost/bob/management/"
+			"value": "http://localhost/bob/management"
 		},
 		{
 			"key": "PROVIDER_PROTOCOL_URL",
@@ -883,7 +1023,7 @@
 		},
 		{
 			"key": "PROVIDER_MANAGEMENT_URL",
-			"value": "http://localhost/alice/management/"
+			"value": "http://localhost/alice/management"
 		},
 		{
 			"key": "ASSET_ID",
@@ -955,8 +1095,13 @@
 			"type": "string"
 		},
 		{
-			"key": "CONSUMER_ADAPTER_URL",
-			"value": "http://localhost:31364/management",
+			"key": "CONSUMER_PROXY_URL",
+			"value": "http://localhost/bob/proxy",
+			"type": "string"
+		},
+		{
+			"key": "PROVIDER_PUBLIC_URL",
+			"value": "http://localhost/alice/api/public",
 			"type": "string"
 		}
 	]

--- a/mxd/postman/mxd-seed.json
+++ b/mxd/postman/mxd-seed.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "8bbb1f64-ca27-4329-ae65-c2c32d99d79f",
+		"_postman_id": "32ff5491-8811-41ba-9560-60b90175f5cb",
 		"name": "MXD Management API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "252261",
-		"_collection_link": "https://winter-rocket-884715.postman.co/workspace/SAP~ff4cf631-05f4-48ab-a1e0-f716cf2efc25/collection/252261-8bbb1f64-ca27-4329-ae65-c2c32d99d79f?action=share&source=collection_link&creator=252261"
+		"_exporter_id": "27652630"
 	},
 	"item": [
 		{
@@ -30,7 +29,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 1\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"1\",\n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 1\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -69,7 +68,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"2\", \n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\"\n    }\n}",
+							"raw": "{\n    \"@context\": {},\n    \"asset\": {\n        \"@type\": \"Asset\",\n        \"@id\": \"2\",\n        \"properties\": {\n            \"description\": \"Product EDC Demo Asset 2\"\n        }\n    },\n    \"dataAddress\": {\n        \"@type\": \"DataAddress\",\n        \"type\": \"HttpData\",\n        \"baseUrl\": \"https://jsonplaceholder.typicode.com/todos\",\n        \"proxyPath\": \"true\",\n        \"proxyQueryParams\": \"true\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"


### PR DESCRIPTION
This PR enriches the EDR tutorial section:

- Updates the REAMDE for the EDR section and some words on the catalog
- Updates the terraform config for exposing the `public`  and the `proxy` endpoints of the participants dataplane.
- Updates the postman collection

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
