### PR TITLE
fix: update EDR negotiation request

### DIFF
--- a/mxd/README.md
+++ b/mxd/README.md
@@ -387,9 +387,9 @@ curl --location 'http://localhost/bob/management/edrs' \
 		"odrl": "http://www.w3.org/ns/odrl/2/"
 	},
 	"@type": "NegotiationInitiateRequestDto",
-	"connectorAddress": "http://alice-controlplane:8084/api/v1/dsp",
+	"counterPartyAddress": "http://alice-controlplane:8084/api/v1/dsp",
 	"protocol": "dataspace-protocol-http",
-	"connectorId": "BPNL000000000001",
+	"counterPartyId": "BPNL000000000001",
 	"providerId": "BPNL000000000001",
 	"offer": {
 		"offerId": "MQ==:MQ==:MDJlMGRlOWUtNzdhZS00N2FhLTg5ODktYzEyMTdhMDE4ZjJh",


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

I noticed that due to the upgrade to EDC 0.4.1 in pull request https://github.com/eclipse-tractusx/tractusx-edc/pull/877, the `curl` command for EDR negotiation mentioned in the `README.md` is causing the following error.

```json
[
  {
    "message": "mandatory value 'https://w3id.org/edc/v0.0.1/ns/counterPartyAddress' is missing or it is blank",
    "type": "ValidationFailure",
    "path": "https://w3id.org/edc/v0.0.1/ns/counterPartyAddress",
    "invalidValue": null
  }
]
```

 This pull request addresses the issue by modifying it to align with the schema of the updated EDR negotiation request.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
