### PR TITLE
fix: Generate private / public key pair for transfer proxy

### DIFF
--- a/mxd/modules/connector/main.tf
+++ b/mxd/modules/connector/main.tf
@@ -53,6 +53,8 @@ resource "helm_release" "connector" {
               "/bin/vault kv put secret/edc.aws.secret.access.key content=${var.minio-config.minio-password}",
               "/bin/vault kv put secret/${var.azure-account-name}-key content=${var.azure-account-key}",
               "/bin/vault kv put secret/${var.azure-account-name}-sas content='${local.azure-sas-token}'",
+              "/bin/vault kv put secret/transferProxyTokenSignerPrivateKey content='${tls_private_key.transfer_proxy_privatekey.private_key_pem}'",
+              "/bin/vault kv put secret/transferProxyTokenSignerPublicKey content='${tls_private_key.transfer_proxy_privatekey.public_key_pem}'",
             ])
           ]
         }
@@ -135,6 +137,10 @@ resource "random_string" "kc_client_secret" {
 
 resource "random_string" "aes_key_raw" {
   length = 16
+}
+
+resource "tls_private_key" "transfer_proxy_privatekey" {
+  algorithm = "ED25519"
 }
 
 locals {

--- a/mxd/modules/connector/values.yaml
+++ b/mxd/modules/connector/values.yaml
@@ -86,6 +86,8 @@ vault:
     token: root
   secretNames:
     transferProxyTokenEncryptionAesKey: aes-keys
+    transferProxyTokenSignerPrivateKey: transferProxyTokenSignerPrivateKey
+    transferProxyTokenSignerPublicKey: transferProxyTokenSignerPublicKey
     # this must be set through CLI args: --set vault.secrets=$YOUR_VAULT_SECRETS where YOUR_VAULT_SECRETS should
     #    # be a string in the format "key1:secret1;key2:secret2;..."
     secrets:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
- Generate private / public key pair.
- Store it in connector's vault.
- Define configs `edc.transfer.proxy.token.signer.privatekey.alias` / `edc.transfer.proxy.token.verifier.publickey.alias`

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Closes #231 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
