### PR TITLE
fix: Make MIW / Keycloak constant static IPs as variables

### DIFF
--- a/mxd/README.md
+++ b/mxd/README.md
@@ -222,6 +222,7 @@ Alternatively, please check out the [Postman collections here](./postman)
 * [File Transfer: Amazon S3 to Azure Blob Storage](./docs/File%20Transfer%20S3%20to%20Azure.md)
 * [Simplify negotiation and transfer using the EDR API](./docs/EDR%20Transfer%20Tutorial.md)
 * [Add a new Participant](./docs/Trudy%20Connector%20Tutorial.md)
+* [Deploying MXD on Remote Kubernetes Cluster (AWS / GCP)](./docs/MXD%20Remote%20Deployment.md)
 
 ## 4. Improving the setup
 

--- a/mxd/docs/MXD Remote Deployment.md
+++ b/mxd/docs/MXD Remote Deployment.md
@@ -1,0 +1,13 @@
+# Deploying MXD on Remote Kubernetes Cluster (AWS / GCP)
+
+We should be able to deploy MXD on a Kubernetes cluster deployed on a local machine / computer as per the steps defined in the [MXD README](../README.md#2-basic-dataspace-setup).
+But there are certain changes needed if we want to deploy it on a remote Kubernetes cluster.
+
+## Provide Static IP for MIW / Keycloak
+MIW and Keycloak both require static IPs.
+Different Kubernetes clusters may have different allowed IP ranges.
+So, we can pass these IPs as Terraform variable while running `terraform apply`.
+
+```shell
+terraform.exe apply -var miw-static-ip="10.96.81.225" -var keycloak-static-ip="10.96.103.90"
+```

--- a/mxd/keycloak.tf
+++ b/mxd/keycloak.tf
@@ -146,6 +146,6 @@ resource "kubernetes_service" "keycloak" {
 }
 
 locals {
-  keycloak-ip  = "10.96.103.80"
+  keycloak-ip  = var.keycloak-static-ip
   keycloak-url = "${local.keycloak-ip}:${var.keycloak-port}"
 }

--- a/mxd/miw.tf
+++ b/mxd/miw.tf
@@ -130,7 +130,7 @@ resource "kubernetes_service" "miw" {
 }
 
 locals {
-  miw-ip         = "10.96.81.222"
+  miw-ip         = var.miw-static-ip
   miw-url        = "${local.miw-ip}:${var.miw-api-port}"
   keycloak-realm = "miw_test"
 }

--- a/mxd/variables.tf
+++ b/mxd/variables.tf
@@ -34,8 +34,16 @@ variable "postgres-port" {
   default = 5432
 }
 
+variable "keycloak-static-ip" {
+  default = "10.96.103.80"
+}
+
 variable "keycloak-port" {
   default = 8080
+}
+
+variable "miw-static-ip" {
+  default = "10.96.81.222"
 }
 
 variable "miw-api-port" {


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
- Changed MIW / Keycloak constant IPs as Terraform variable.
- Added a readme, how to override these variables.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Closes #275 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
