### PR TITLE
chore: define json path leading to atrributes in job response

### DIFF
--- a/icc-irs-challenges/ki-assistent.md
+++ b/icc-irs-challenges/ki-assistent.md
@@ -190,7 +190,7 @@ curl --request GET \
     - Attach fields from shells to shells graph node
   - From submodels[] array 
     - Get submodel with `aspectType`: `urn:samm:io.catenax.single_level_bom_as_built:3.0.0#SingleLevelBomAsBuilt`
-    - Attach submodel from submodels to submodels graph edge (`catenaXId`, `childItems`:[`catenaXId`,`businessPartner`])
+  - Attach fields submodels graph edge (`submodels[?].payload.catenaXId`, `submodels[?].payload.childItems[?].catenaXId`,`submodels[?].payload.childItems[?].businessPartner`)
 - Ensure JSON data is now structured and visually accessible in HTML.
 - Present the result and gather feedback.
 
@@ -214,7 +214,7 @@ curl --request GET \
 - From submodels[] array
   - Get submodel with `aspectType`: `urn:samm:io.catenax.single_level_bom_as_built:3.0.0#SingleLevelBomAsBuilt`
   - Attach submodel from submodels to submodels graph edge 
-  - Attach fields submodels graph edge (`catenaXId`, `childItems`:[`catenaXId`,`businessPartner`])
+  - Attach fields submodels graph edge (`submodels[?].payload.catenaXId`, `submodels[?].payload.childItems[?].catenaXId`,`submodels[?].payload.childItems[?].businessPartner`)
 - In case of `aspectType`: `urn:samm:io.catenax.serial_part:3.0.0#SerialPart`
   - Extract fields from shells (`partInstanceId`, `intrinsicId`, `van`)
 - In case of `aspectType`: `urn:samm:io.catenax.batch:3.0.0#Batch`
@@ -224,15 +224,15 @@ curl --request GET \
 - From submodels[] array
   - Get submodel with `aspectType`: `urn:samm:io.catenax.serial_part:3.0.0#SerialPart`
   - Attach submodel from submodels as graph node
-  - Attach fields submodels graph edge (`manufacturingInformation`:`date`, `manufacturingInformation`:`country`, `nameAtManufacturer`, `nameAtCustomer`, `customerPartId`)
+  - Attach fields submodels graph edge (`submodels[?].payload.manufacturingInformationdate`, `submodels[?].payload.manufacturingInformationcountry`, `submodels[?].payload.partTypeInformation.nameAtManufacturer`, `submodels[?].payload.partTypeInformation.nameAtCustomer`, `submodels[?].payload.partTypeInformation.customerPartId`)
 - From submodels[] array
   - Get submodel with `aspectType`: `urn:samm:io.catenax.batch:3.0.0#Batch`
   - Attach submodel from submodels as graph node
-  - Attach fields submodels graph edge (`manufacturingInformation`:`date`, `manufacturingInformation`:`country`, `nameAtManufacturer`, `nameAtCustomer`, `customerPartId`)
+  - Attach fields submodels graph edge (`submodels[?].payload.manufacturingInformation.date`, `submodels[?].payload.manufacturingInformation.country`, `submodels[?].payload.nameAtManufacturer`, `submodels[?].payload.partTypeInformation..nameAtCustomer`, `submodels[?].payload.partTypeInformation.customerPartId`)
 - From submodels[] array
   - Get submodel with `aspectType`: `urn:samm:io.catenax.just_in_sequence_part:3.0.0#JustInSequencePart`
   - Attach submodel from submodels as graph node
-  - Attach fields submodels graph edge (`manufacturingInformation`:`date`, `manufacturingInformation`:`country`, `partTypeInformation`:`manufacturerPartId`, `partTypeInformation`:`nameAtManufacturer`)
+  - Attach fields submodels graph edge (`submodels[?].payload.manufacturingInformation.date`, `submodels[?].payload.manufacturingInformation.country`, `submodels[?].payload.partTypeInformation.manufacturerPartId`, `submodels[?].payload.partTypeInformation.nameAtManufacturer`)
 - Present the result and gather final feedback.
 - **Next Step**: Inform participants they can refine and style the graph creatively. Encourage questions about styling. Ask if they want to extend the solution further or finalize the workshop.
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
update son path leading to attributes inside job response payloa
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x]  [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
