### PR TITLE
fix(deployment): use correct catalogserver url

### DIFF
--- a/mxd/README.md
+++ b/mxd/README.md
@@ -31,6 +31,9 @@ For the most bare-bones installation of the dataspace, execute the following com
 
 ### 2.1 Creating the cluster
 
+
+
+
 We are using KinD as Kubernetes runtime, so all commands here relate to that. First, we need to create a cluster and
 install an ingress controller. We'll be using NGINX for that.
 

--- a/mxd/alice.tf
+++ b/mxd/alice.tf
@@ -100,7 +100,7 @@ module "alice-catalog-server" {
   }
   dcp-config = {
     id                     = var.alice-did
-    sts_token_url          = local.sts-accounts-url
+    sts_token_url          = local.sts-token-url
     sts_client_id          = var.alice-did
     sts_clientsecret_alias = "participant-alice-sts-client-secret"
   }

--- a/mxd/assets/participants.json
+++ b/mxd/assets/participants.json
@@ -8,7 +8,7 @@
   {
     "name": "alice",
     "id": "BPNL000000000001",
-    "url": "http://alice-controlplane:8084/api/v1/dsp",
+    "url": "http://alice-cs:8082/api/dsp",
     "supportedProtocols": "dataspace-protocol-http"
   }
 ]


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
use the correct CatalogServer url, it was wrong before.
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
