### PR TITLE
Update run-end2end-tests.yml

### DIFF
--- a/.github/workflows/run-end2end-tests.yml
+++ b/.github/workflows/run-end2end-tests.yml
@@ -68,6 +68,9 @@ jobs:
         run: |-
           kind load docker-image --name mxd data-service-api tx-identityhub tx-identityhub-sts tx-catalog-server tx-sts
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        
       - name: "Terraform init"
         working-directory: mxd
         run: |-


### PR DESCRIPTION
## Description

Fix the bug 
+ https://github.com/eclipse-tractusx/tutorial-resources/issues/475

add Setup Terraform in [run-end2end-test.yml](https://github.com/eclipse-tractusx/tutorial-resources/blob/main/.github/workflows/run-end2end-tests.yml)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [X] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [X] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
