### PR TITLE
docs: Add Java as a prerequisite for MXD

### DIFF
--- a/mxd/README.md
+++ b/mxd/README.md
@@ -5,7 +5,7 @@
 In order to run the Minimum Tractus-X Dataspace "MXD" on your local machine, please make sure the following
 preconditions are met.
 
-- Install the Java Development Kit ([JDK](https://adoptium.net/temurin/releases/)) version 21 <!-- java-version: 21 --> and set the `JAVA_HOME` environment variable in your system.
+- Install the Java Development Kit ([JDK](https://adoptium.net/temurin/releases/)) version 17+ and set the `JAVA_HOME` environment variable in your system.
 - Have a local Kubernetes runtime ready. We've tested this setup with [KinD](https://kind.sigs.k8s.io/), but other
   runtimes such
   as [Minikube](https://minikube.sigs.k8s.io/docs/start/) may work as well, we just haven't tested them. All following

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -5,6 +5,7 @@
 In order to run the Minimum Tractus-X Dataspace "MXD" on your local machine, please make sure the following
 preconditions are met.
 
+- Install Java Development Kit ([JDK](https://www.oracle.com/java/technologies/downloads/)) and set the `JAVA_HOME` variable in your environment.
 - Have a local Kubernetes runtime ready. We've tested this setup with [KinD](https://kind.sigs.k8s.io/), but other
   runtimes such
   as [Minikube](https://minikube.sigs.k8s.io/docs/start/) may work as well, we just haven't tested them. All following

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -5,7 +5,7 @@
 In order to run the Minimum Tractus-X Dataspace "MXD" on your local machine, please make sure the following
 preconditions are met.
 
-- Install Java Development Kit ([JDK](https://www.oracle.com/java/technologies/downloads/)) and set the `JAVA_HOME` variable in your environment.
+- Install the Java Development Kit ([JDK](https://adoptium.net/temurin/releases/)) version 21 <!-- java-version: 21 --> and set the `JAVA_HOME` environment variable in your system.
 - Have a local Kubernetes runtime ready. We've tested this setup with [KinD](https://kind.sigs.k8s.io/), but other
   runtimes such
   as [Minikube](https://minikube.sigs.k8s.io/docs/start/) may work as well, we just haven't tested them. All following

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -5,7 +5,7 @@
 In order to run the Minimum Tractus-X Dataspace "MXD" on your local machine, please make sure the following
 preconditions are met.
 
-- Install the Java Development Kit ([JDK](https://adoptium.net/temurin/releases/)) version 17+ and set the `JAVA_HOME` environment variable in your system.
+- Install the Java Development Kit ([JDK](https://adoptium.net/temurin/releases/)) [version 17+](https://eclipse-edc.github.io/documentation/for-contributors/#11-prerequisites) and set the `JAVA_HOME` environment variable in your system.
 - Have a local Kubernetes runtime ready. We've tested this setup with [KinD](https://kind.sigs.k8s.io/), but other
   runtimes such
   as [Minikube](https://minikube.sigs.k8s.io/docs/start/) may work as well, we just haven't tested them. All following


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->
Corrected the documentation of `Minimum Tractus-X Dataspace` to have `JDK` as a prerequisite.
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Fixes  #411 
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
