### PR TITLE
feat: upgrade IdentityHub

### DIFF
--- a/mxd-runtimes/gradle/libs.versions.toml
+++ b/mxd-runtimes/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ format.version = "1.1"
 awaitility = "4.2.2"
 assertj = "3.25.3"
 edc = "0.10.1"
+ih = "0.12.0-SNAPSHOT"
 tractusx = "0.8.0"
 commons = "2.11.0"
 opentelemetry = "1.32.0"
@@ -22,6 +23,7 @@ swagger = "2.2.24"
 # Connector dependencies
 edc-build-plugin = { module = "org.eclipse.edc.edc-build:org.eclipse.edc.edc-build.gradle.plugin", version.ref = "edc" }
 edc-vault-hashicorp = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "edc" }
+edc-vault-hashicorp-ih = { module = "org.eclipse.edc:vault-hashicorp", version.ref = "ih" }
 edc-boot = { module = "org.eclipse.edc:boot", version.ref = "edc" }
 edc-junit = { module = "org.eclipse.edc:junit", version.ref = "edc" }
 
@@ -32,6 +34,7 @@ edc-sql-transactionlocal = { module = "org.eclipse.edc:transaction-local", versi
 edc-did-core = { module = "org.eclipse.edc:identity-did-core", version.ref = "edc" }
 edc-did-web = { module = "org.eclipse.edc:identity-did-web", version.ref = "edc" }
 edc-core-connector = { module = "org.eclipse.edc:connector-core", version.ref = "edc" }
+edc-core-connector-ih = { module = "org.eclipse.edc:connector-core", version.ref = "ih" }
 edc-ext-http = { module = "org.eclipse.edc:http", version.ref = "edc" }
 edc-core-jersey = { module = "org.eclipse.edc:jersey-core", version.ref = "edc" }
 edc-ext-jsonld = { module = "org.eclipse.edc:json-ld", version.ref = "edc" }
@@ -47,23 +50,25 @@ edc-api-observability = { module = "org.eclipse.edc:api-observability", version.
 # EDC lib dependencies
 edc-http-lib = { module = "org.eclipse.edc:http-lib", version.ref = "edc" }
 edc-lib-crypto = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "edc" }
+edc-lib-crypto-ih = { module = "org.eclipse.edc:crypto-common-lib", version.ref = "ih" }
 edc-lib-keys = { module = "org.eclipse.edc:keys-lib", version.ref = "edc" }
+edc-lib-keys-ih = { module = "org.eclipse.edc:keys-lib", version.ref = "ih" }
 edc-lib-transform = { module = "org.eclipse.edc:transform-lib", version.ref = "edc" }
 edc-lib-jsonld = { module = "org.eclipse.edc:json-ld-lib", version.ref = "edc" }
 
 # identith-hub modules
-edc-ih-spi = { module = "org.eclipse.edc:identity-hub-spi", version.ref = "edc" }
-edc-ih-account-remote = { module = "org.eclipse.edc:sts-account-service-remote", version.ref = "edc" }
+edc-ih-spi = { module = "org.eclipse.edc:identity-hub-spi", version.ref = "ih" }
+edc-ih-account-remote = { module = "org.eclipse.edc:sts-account-service-remote", version.ref = "ih" }
 
 # identity hub BOM modules
-bom-ih-withsts = { module = "org.eclipse.edc:identityhub-with-sts-bom", version.ref = "edc" }
-bom-ih = { module = "org.eclipse.edc:identityhub-bom", version.ref = "edc" }
-bom-ih-sql = { module = "org.eclipse.edc:identityhub-feature-sql-bom", version.ref = "edc" }
-bom-ih-sql-sts = { module = "org.eclipse.edc:identityhub-feature-sql-sts-bom", version.ref = "edc" }
+bom-ih-withsts = { module = "org.eclipse.edc:identityhub-with-sts-bom", version.ref = "ih" }
+bom-ih = { module = "org.eclipse.edc:identityhub-bom", version.ref = "ih" }
+bom-ih-sql = { module = "org.eclipse.edc:identityhub-feature-sql-bom", version.ref = "ih" }
+bom-ih-sql-sts = { module = "org.eclipse.edc:identityhub-feature-sql-sts-bom", version.ref = "ih" }
 
 # STS modules
-edc-sql-sts-store = { module = "org.eclipse.edc:sts-client-store-sql", version.ref = "edc" }
-bom-sts = { module = "org.eclipse.edc:sts-feature-bom", version.ref = "edc" }
+edc-sql-sts-store = { module = "org.eclipse.edc:sts-client-store-sql", version.ref = "ih" }
+bom-sts = { module = "org.eclipse.edc:sts-feature-bom", version.ref = "ih" }
 
 # Tractus-X Runtime BOMs
 edc-tx-controlplane = { module = "org.eclipse.tractusx.edc:edc-controlplane-postgresql-hashicorp-vault", version.ref = "tractusx" }

--- a/mxd-runtimes/jwt-signer/build.gradle.kts
+++ b/mxd-runtimes/jwt-signer/build.gradle.kts
@@ -21,8 +21,8 @@ plugins {
 dependencies {
 
     implementation(libs.edc.spi.did)
-    implementation(libs.edc.lib.crypto)
-    implementation(libs.edc.lib.keys)
+    implementation(libs.edc.lib.crypto.ih)
+    implementation(libs.edc.lib.keys.ih)
     implementation(libs.edc.junit)
 }
 

--- a/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.demo;
 
-import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
+import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;

--- a/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.demo;
 
-import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
+import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 

--- a/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
+++ b/mxd-runtimes/tx-identityhub-sts/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
@@ -91,7 +91,7 @@ public class SuperUserSeedExtension implements ServiceExtension {
                                         .onFailure(f -> monitor.warning("Error overriding API key for '%s': %s".formatted(superUserParticipantId, f.getFailureDetail())));
                                 return key;
                             })
-                            .orElse(generatedKey.get("apiKey").toString());
+                            .orElse(generatedKey.apiKey());
                     monitor.info("Created user 'super-user'. Please take note of the API Key: %s".formatted(apiKey));
                 })
                 .orElseThrow(f -> new EdcException("Error creating Super-User: " + f.getFailureDetail()));

--- a/mxd-runtimes/tx-identityhub-sts/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
+++ b/mxd-runtimes/tx-identityhub-sts/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.seed;
 
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.CreateParticipantContextResponse;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.EdcException;
@@ -60,7 +61,8 @@ class ParticipantContextSeedExtensionTest {
                                ServiceExtensionContext context) {
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "some-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("some-key", null, null)));
+
 
         ext.initialize(context);
 
@@ -95,7 +97,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -118,7 +120,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -142,7 +144,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -158,7 +160,7 @@ class ParticipantContextSeedExtensionTest {
 
     private ParticipantContext.Builder superUserContext() {
         return ParticipantContext.Builder.newInstance()
-                .participantId(SUPER_USER)
+                .participantContextId(SUPER_USER)
                 .apiTokenAlias("super-user-apikey");
 
     }

--- a/mxd-runtimes/tx-identityhub/build.gradle.kts
+++ b/mxd-runtimes/tx-identityhub/build.gradle.kts
@@ -24,14 +24,14 @@ dependencies {
     runtimeOnly(libs.bom.ih)
     runtimeOnly(libs.bom.ih.sql)
     runtimeOnly(libs.edc.ih.account.remote)
-    runtimeOnly(libs.edc.vault.hashicorp)
+    runtimeOnly(libs.edc.vault.hashicorp.ih)
 
     // used for custom extensions
-    implementation(libs.edc.core.connector)
+    implementation(libs.edc.core.connector.ih)
     implementation(libs.edc.ih.spi)
 
-    testImplementation(libs.edc.lib.crypto)
-    testImplementation(libs.edc.lib.keys)
+    testImplementation(libs.edc.lib.crypto.ih)
+    testImplementation(libs.edc.lib.keys.ih)
     testImplementation(libs.edc.junit)
 }
 

--- a/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
+++ b/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/demo/IdentityHubExtension.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.demo;
 
-import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
+import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.runtime.metamodel.annotation.Extension;
 import org.eclipse.edc.runtime.metamodel.annotation.Provider;
 import org.eclipse.edc.spi.system.ServiceExtension;

--- a/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
+++ b/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/demo/TxScopeToCriterionTransformer.java
@@ -14,7 +14,7 @@
 
 package org.eclipse.edc.identityhub.demo;
 
-import org.eclipse.edc.identityhub.spi.ScopeToCriterionTransformer;
+import org.eclipse.edc.identityhub.spi.transformation.ScopeToCriterionTransformer;
 import org.eclipse.edc.spi.query.Criterion;
 import org.eclipse.edc.spi.result.Result;
 

--- a/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
+++ b/mxd-runtimes/tx-identityhub/src/main/java/org/eclipse/edc/identityhub/seed/SuperUserSeedExtension.java
@@ -91,7 +91,7 @@ public class SuperUserSeedExtension implements ServiceExtension {
                                         .onFailure(f -> monitor.warning("Error overriding API key for '%s': %s".formatted(superUserParticipantId, f.getFailureDetail())));
                                 return key;
                             })
-                            .orElse(generatedKey.get("apiKey").toString());
+                            .orElse(superUserApiKey);
                     monitor.info("Created user 'super-user'. Please take note of the API Key: %s".formatted(apiKey));
                 })
                 .orElseThrow(f -> new EdcException("Error creating Super-User: " + f.getFailureDetail()));

--- a/mxd-runtimes/tx-identityhub/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
+++ b/mxd-runtimes/tx-identityhub/src/test/java/org/eclipse/edc/identityhub/seed/ParticipantContextSeedExtensionTest.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.identityhub.seed;
 
 import org.eclipse.edc.identityhub.spi.participantcontext.ParticipantContextService;
+import org.eclipse.edc.identityhub.spi.participantcontext.model.CreateParticipantContextResponse;
 import org.eclipse.edc.identityhub.spi.participantcontext.model.ParticipantContext;
 import org.eclipse.edc.junit.extensions.DependencyInjectionExtension;
 import org.eclipse.edc.spi.EdcException;
@@ -60,7 +61,7 @@ class ParticipantContextSeedExtensionTest {
                                ServiceExtensionContext context) {
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "some-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("some-key", null, null)));
 
         ext.initialize(context);
 
@@ -95,7 +96,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -118,7 +119,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -142,7 +143,7 @@ class ParticipantContextSeedExtensionTest {
                 .thenReturn(apiKeyOverride);
 
         when(participantContextService.createParticipantContext(any()))
-                .thenReturn(ServiceResult.success(Map.of("apiKey", "generated-api-key")));
+                .thenReturn(ServiceResult.success(new CreateParticipantContextResponse("generated-api-key", null, null)));
         when(participantContextService.getParticipantContext(eq(SUPER_USER)))
                 .thenReturn(ServiceResult.notFound("foobar"))
                 .thenReturn(ServiceResult.success(superUserContext().build()));
@@ -158,7 +159,7 @@ class ParticipantContextSeedExtensionTest {
 
     private ParticipantContext.Builder superUserContext() {
         return ParticipantContext.Builder.newInstance()
-                .participantId(SUPER_USER)
+                .participantContextId(SUPER_USER)
                 .apiTokenAlias("super-user-apikey");
 
     }

--- a/mxd/README.md
+++ b/mxd/README.md
@@ -96,7 +96,24 @@ switch.
 
 ![img.png](assets/img.png)
 
-### Inspect terraform output
+### 2.4 JVM crashes with `SIGILL` on ARM platforms
+
+We have noticed that the JVM inside the Docker container sometimes crashes with a `SIGILL` signal right
+away without even starting the runtime. So far we've only seen this on ARM platforms such as Apple Silicon. The `UseSVE`
+option seems to [mitigate this](https://github.com/corretto/corretto-21/issues/85). If you are affected by this, please
+try enabling the `useSVE` switch:
+
+```
+terraform apply -var="useSVE=true"
+```
+
+This will add the `-XX:UseSVE=0` switch to the `JAVA_TOOL_OPTIONS` in all runtimes, enabling the Scalable Vector
+Extensions that are available on ARM processors. Alternatively, you can also set the `useSVE = true` variable in a
+`*.tfvars` file, cf. [documentation](https://developer.hashicorp.com/terraform/language/values/variables).
+
+_Important note: on non-ARM platforms, the `-XX:UseSVE=0` VM option is not recognized and will crash the JVM!_
+
+### 2.5 Inspect terraform output
 
 After the `terraform` command has successfully completed, it will output a few configuration and setup values
 that we will need in later steps. Please note that some values will be different on your local system.
@@ -132,7 +149,7 @@ bob-urls = {
 }
 ```
 
-### Inspect the databases
+### 2.6 Inspect the databases
 
 None of the services and applications that were deployed in the previous step are accessible from
 outside the Kubernetes cluster. That means, for example, the Postgres database cannot be reached out-of-the-box. Every
@@ -159,7 +176,7 @@ Every service in the cluster has their own PostgreSQL instance, containing table
 Control Plane, Federated Catalog Cache and Identity Hub. Feel free to inspect the tables, some of them already have data
 in them which got automatically seeded assets, policies and contract definitions as well as IdentityHub data.
 
-### Verify your local installation
+### 2.6 Verify your local installation
 
 In order to check that the connectors were deployed successfully, please execute the following commands in a shell:
 
@@ -288,7 +305,7 @@ curl -X POST http://localhost/alice/management/v2/policydefinitions/request -H "
 curl -X POST http://localhost/alice/management/v2/contractdefinitions/request -H "x-api-key: password" -H "content-type: application/json" | jq
 ```
 
-### Use Postman collections to communicate with your services
+### 2.7 Use Postman collections to communicate with your services
 
 There are several collections in the `mxd/postman` folder:
 

--- a/mxd/alice.tf
+++ b/mxd/alice.tf
@@ -66,6 +66,7 @@ module "alice-identityhub" {
   sts_token_url     = local.sts-token-url
   sts_accounts_url  = local.sts-accounts-url
   image             = "tx-identityhub:latest" # the one without the STS, which is deployed standalone
+  useSVE = var.useSVE
 }
 
 module "alice-sts" {
@@ -80,6 +81,7 @@ module "alice-sts" {
     password = local.databases.alice.database-password
     url      = "jdbc:postgresql://${local.alice-postgres.database-host}/${local.databases.alice.database-name}"
   }
+  useSVE = var.useSVE
 }
 
 # alice's catalog server
@@ -104,6 +106,7 @@ module "alice-catalog-server" {
     sts_client_id          = var.alice-did
     sts_clientsecret_alias = "participant-alice-sts-client-secret"
   }
+  useSVE = var.useSVE
 }
 
 

--- a/mxd/bob.tf
+++ b/mxd/bob.tf
@@ -60,6 +60,7 @@ module "bob-identityhub" {
   participantId     = var.bob-did
   vault-url         = "http://bob-vault:8200"
   url-path          = var.bob-identityhub-host
+  useSVE = var.useSVE
 }
 
 module "bob-minio" {

--- a/mxd/data-service-api.tf
+++ b/mxd/data-service-api.tf
@@ -64,7 +64,7 @@ resource "kubernetes_deployment" "data-service-api" {
           }
           env {
             name  = "JAVA_TOOL_OPTIONS"
-            value = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044"
+            value = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044"
           }
           readiness_probe {
             http_get {

--- a/mxd/modules/catalog-server/catalog-server.tf
+++ b/mxd/modules/catalog-server/catalog-server.tf
@@ -129,7 +129,7 @@ resource "kubernetes_config_map" "catalog-server-config" {
     EDC_DSP_CALLBACK_ADDRESS        = "http://${var.serviceName}:${var.ports.protocol}/api/dsp"
     EDC_IAM_STS_PRIVATEKEY_ALIAS    = "${var.participantId}#${var.aliases.sts-private-key}"
     EDC_IAM_STS_PUBLICKEY_ID        = "${var.participantId}#${var.aliases.sts-public-key-id}"
-    JAVA_TOOL_OPTIONS               = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.debug}"
+    JAVA_TOOL_OPTIONS               = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.debug}"
     EDC_IH_AUDIENCE_REGISTRY_PATH   = "/etc/registry/registry.json"
     EDC_PARTICIPANT_ID              = var.participantId
     EDC_VAULT_HASHICORP_URL         = var.vault-url

--- a/mxd/modules/catalog-server/variables.tf
+++ b/mxd/modules/catalog-server/variables.tf
@@ -108,6 +108,11 @@ variable "aliases" {
     sts-public-key-id = "key-1"
   }
 }
+variable "useSVE" {
+  type        = bool
+  description = "If true, the -XX:UseSVE=0 switch (Scalable Vector Extensions) will be appended to the JAVA_TOOL_OPTIONS. Can help on macOs on Apple Silicon processors"
+  default     = false
+}
 
 locals {
   name = lower(var.serviceName)

--- a/mxd/modules/connector/variables.tf
+++ b/mxd/modules/connector/variables.tf
@@ -108,3 +108,10 @@ variable "ingress-host" {
   description = "Ingress Host"
   default     = "localhost"
 }
+
+variable "useSVE" {
+  type        = bool
+  description = "If true, the -XX:UseSVE=0 switch (Scalable Vector Extensions) will be appended to the JAVA_TOOL_OPTIONS. Can help on macOs on Apple Silicon processors"
+  default     = false
+}
+

--- a/mxd/modules/identity-hub/identityhub.tf
+++ b/mxd/modules/identity-hub/identityhub.tf
@@ -13,7 +13,7 @@
 
 resource "kubernetes_deployment" "identityhub" {
   metadata {
-    name      = lower(var.humanReadableName)
+    name = lower(var.humanReadableName)
     namespace = var.namespace
     labels = {
       App = lower(var.humanReadableName)
@@ -116,36 +116,36 @@ resource "kubernetes_config_map" "identityhub-config" {
 
   data = {
     # IdentityHub variables
-    EDC_API_AUTH_KEY                       = "password"
-    EDC_IH_IAM_ID                          = var.participantId
-    EDC_IAM_DID_WEB_USE_HTTPS              = false
-    EDC_IH_IAM_PUBLICKEY_ALIAS             = local.public-key-alias
-    EDC_IH_API_SUPERUSER_KEY               = var.ih_superuser_apikey
-    WEB_HTTP_PORT                          = var.ports.web
-    WEB_HTTP_PATH                          = "/api"
-    WEB_HTTP_IDENTITY_PORT                 = var.ports.ih-identity-api
-    WEB_HTTP_IDENTITY_PATH                 = "/api/identity"
-    WEB_HTTP_PRESENTATION_PORT             = var.ports.presentation-api
-    WEB_HTTP_PRESENTATION_PATH             = "/api/presentation"
-    WEB_HTTP_STS_PORT                      = var.ports.ih-sts
-    WEB_HTTP_STS_PATH                      = "/api/credentials"
-    WEB_HTTP_DID_PORT                      = var.ports.ih-did
-    WEB_HTTP_DID_PATH                      = "/"
-    JAVA_TOOL_OPTIONS                      = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.ih-debug}"
-    EDC_IAM_STS_PRIVATEKEY_ALIAS           = var.aliases.sts-private-key
-    EDC_IAM_STS_PUBLICKEY_ID               = var.aliases.sts-public-key-id
-    EDC_MVD_CREDENTIALS_PATH               = "/etc/credentials/"
-    EDC_VAULT_HASHICORP_URL                = var.vault-url
-    EDC_VAULT_HASHICORP_TOKEN              = var.vault-token
-    EDC_DATASOURCE_DEFAULT_URL             = var.database.url
-    EDC_DATASOURCE_DEFAULT_USER            = var.database.user
-    EDC_DATASOURCE_DEFAULT_PASSWORD        = var.database.password
-    EDC_SQL_SCHEMA_AUTOCREATE              = true
-    EDC_IAM_DID_WEB_USE_HTTPS              = "false"
-    EDC_STS_ACCOUNT_API_URL                = var.sts_accounts_url
+    EDC_IH_IAM_ID                   = var.participantId
+    EDC_IAM_DID_WEB_USE_HTTPS       = false
+    EDC_IH_IAM_PUBLICKEY_ALIAS      = local.public-key-alias
+    EDC_IH_API_SUPERUSER_KEY        = var.ih_superuser_apikey
+    WEB_HTTP_PORT                   = var.ports.web
+    WEB_HTTP_PATH                   = "/api"
+    WEB_HTTP_IDENTITY_PORT          = var.ports.ih-identity-api
+    WEB_HTTP_IDENTITY_PATH          = "/api/identity"
+    WEB_HTTP_IDENTITY_AUTH_KEY      = "password"
+    WEB_HTTP_PRESENTATION_PORT      = var.ports.presentation-api
+    WEB_HTTP_PRESENTATION_PATH      = "/api/presentation"
+    WEB_HTTP_STS_PORT               = var.ports.ih-sts
+    WEB_HTTP_STS_PATH               = "/api/credentials"
+    WEB_HTTP_DID_PORT               = var.ports.ih-did
+    WEB_HTTP_DID_PATH               = "/"
+    JAVA_TOOL_OPTIONS               = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=${var.ports.ih-debug}"
+    EDC_IAM_STS_PRIVATEKEY_ALIAS    = var.aliases.sts-private-key
+    EDC_IAM_STS_PUBLICKEY_ID        = var.aliases.sts-public-key-id
+    EDC_MVD_CREDENTIALS_PATH        = "/etc/credentials/"
+    EDC_VAULT_HASHICORP_URL         = var.vault-url
+    EDC_VAULT_HASHICORP_TOKEN       = var.vault-token
+    EDC_DATASOURCE_DEFAULT_URL      = var.database.url
+    EDC_DATASOURCE_DEFAULT_USER     = var.database.user
+    EDC_DATASOURCE_DEFAULT_PASSWORD = var.database.password
+    EDC_SQL_SCHEMA_AUTOCREATE       = true
+    EDC_IAM_DID_WEB_USE_HTTPS       = "false"
+    EDC_STS_ACCOUNT_API_URL         = var.sts_accounts_url
     EDC_STS_ACCOUNTS_API_AUTH_HEADER_VALUE = var.sts_accounts_api_key
     // only relevant when the STS is not embedded
-    EDC_API_ACCOUNTS_KEY = "password"
+    WEB_HTTP_STS-ACCOUNTS_KEY       = "password"
   }
 }
 

--- a/mxd/modules/identity-hub/variables.tf
+++ b/mxd/modules/identity-hub/variables.tf
@@ -119,3 +119,8 @@ variable "sts_accounts_api_key" {
   default     = "password"
   description = "API Key for the STS Accounts API of a standalone STS"
 }
+variable "useSVE" {
+  type        = bool
+  description = "If true, the -XX:UseSVE=0 switch (Scalable Vector Extensions) will be appended to the JAVA_TOOL_OPTIONS. Can help on macOs on Apple Silicon processors"
+  default     = false
+}

--- a/mxd/modules/sts/sts.tf
+++ b/mxd/modules/sts/sts.tf
@@ -13,7 +13,7 @@
 
 resource "kubernetes_deployment" "sts" {
   metadata {
-    name      = lower(var.humanReadableName)
+    name = lower(var.humanReadableName)
     namespace = var.namespace
     labels = {
       App = lower(var.humanReadableName)
@@ -107,7 +107,7 @@ resource "kubernetes_config_map" "sts-config" {
 
   data = {
     # STS variables
-    EDC_API_ACCOUNTS_KEY            = var.accounts-api-key
+    WEB_HTTP_STS-ACCOUNTS_KEY            = var.accounts-api-key
     WEB_HTTP_ACCOUNTS_PORT          = var.ports.accounts
     WEB_HTTP_ACCOUNTS_PATH          = var.paths.accounts
     WEB_HTTP_STS_PORT               = var.ports.sts
@@ -120,5 +120,6 @@ resource "kubernetes_config_map" "sts-config" {
     EDC_SQL_SCHEMA_AUTOCREATE       = true
     EDC_VAULT_HASHICORP_URL         = var.vault-url
     EDC_VAULT_HASHICORP_TOKEN       = var.vault-token
+    JAVA_TOOL_OPTIONS = "${var.useSVE ? "-XX:UseSVE=0 " : ""}-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=1044"
   }
 }

--- a/mxd/modules/sts/variables.tf
+++ b/mxd/modules/sts/variables.tf
@@ -71,3 +71,9 @@ variable "vault-token" {
   description = "This is the authentication token for the vault. DO NOT USE THIS IN PRODUCTION!"
   type        = string
 }
+
+variable "useSVE" {
+  type        = bool
+  description = "If true, the -XX:UseSVE=0 switch (Scalable Vector Extensions) will be appended to the JAVA_TOOL_OPTIONS. Can help on macOs on Apple Silicon processors"
+  default     = false
+}

--- a/mxd/postman/mxd-seed.json
+++ b/mxd/postman/mxd-seed.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "079819cb-65da-40ac-9808-c19411a81c49",
+		"_postman_id": "33b50155-e66e-4c82-88e6-a7c5fa73aa37",
 		"name": "MXD Management API Seed",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "647585"
@@ -953,8 +953,11 @@
 						{
 							"listen": "prerequest",
 							"script": {
-								"exec": [],
-								"type": "text/javascript"
+								"exec": [
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
 							}
 						}
 					],
@@ -963,7 +966,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"membership-credential\",\n    \"participantId\": \"{{PARTICIPANT_CONTEXT_ID}}\",\n    \"issuancePolicy\": null,\n    \"reissuancePolicy\": null,\n    \"verifiableCredentialContainer\": {\n        \"format\": \"JWT\",\n        \"credential\": {\n            \"@context\": [\n                \"https://www.w3.org/2018/credentials/v1\",\n                \"https://w3id.org/security/suites/jws-2020/v1\",\n                \"https://www.w3.org/ns/did/v1\",\n                {\n                    \"mxd-credentials\": \"https://w3id.org/mxd/credentials/\",\n                    \"membership\": \"mxd-credentials:membership\",\n                    \"membershipType\": \"mxd-credentials:membershipType\",\n                    \"website\": \"mxd-credentials:website\",\n                    \"contact\": \"mxd-credentials:contact\",\n                    \"since\": \"mxd-credentials:since\"\n                }\n            ],\n            \"id\": \"http://org.yourdataspace.com/credentials/2347\",\n            \"type\": [\n                \"VerifiableCredential\",\n                \"MembershipCredential\"\n            ],\n            \"issuer\": \"did:web:dataspace-issuer\",\n            \"issuanceDate\": \"2023-08-18T00:00:00Z\",\n            \"credentialSubject\": {\n                \"id\": \"{{PARTICIPANT_DID}}\",\n                \"membership\": {\n                    \"membershipType\": \"FullMember\",\n                    \"website\": \"www.whatever.com\",\n                    \"contact\": \"fizz.buzz@whatever.com\",\n                    \"since\": \"2023-01-01T00:00:00Z\"\n                }\n            }\n        },\n        \"rawVc\": \"{{MEMBERSHIP_CREDENTIAL}}\"\n    }\n}",
+							"raw": "{\n    \"id\": \"membership-credential\",\n    \"participantContextId\": \"{{PARTICIPANT_CONTEXT_ID}}\",\n    \"issuancePolicy\": null,\n    \"reissuancePolicy\": null,\n    \"verifiableCredentialContainer\": {\n        \"format\": \"JWT\",\n        \"credential\": {\n            \"@context\": [\n                \"https://www.w3.org/2018/credentials/v1\",\n                \"https://w3id.org/security/suites/jws-2020/v1\",\n                \"https://www.w3.org/ns/did/v1\",\n                {\n                    \"mxd-credentials\": \"https://w3id.org/mxd/credentials/\",\n                    \"membership\": \"mxd-credentials:membership\",\n                    \"membershipType\": \"mxd-credentials:membershipType\",\n                    \"website\": \"mxd-credentials:website\",\n                    \"contact\": \"mxd-credentials:contact\",\n                    \"since\": \"mxd-credentials:since\"\n                }\n            ],\n            \"id\": \"http://org.yourdataspace.com/credentials/2347\",\n            \"type\": [\n                \"VerifiableCredential\",\n                \"MembershipCredential\"\n            ],\n            \"issuer\": \"did:web:dataspace-issuer\",\n            \"issuanceDate\": \"2023-08-18T00:00:00Z\",\n            \"credentialSubject\": {\n                \"id\": \"{{PARTICIPANT_DID}}\",\n                \"membership\": {\n                    \"membershipType\": \"FullMember\",\n                    \"website\": \"www.whatever.com\",\n                    \"contact\": \"fizz.buzz@whatever.com\",\n                    \"since\": \"2023-01-01T00:00:00Z\"\n                }\n            }\n        },\n        \"rawVc\": \"{{MEMBERSHIP_CREDENTIAL}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -1018,7 +1021,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n    \"id\": \"deg-credential\",\n    \"participantId\": \"{{PARTICIPANT_CONTEXT_ID}}\",\n    \"issuancePolicy\": null,\n    \"reissuancePolicy\": null,\n    \"verifiableCredentialContainer\": {\n        \"format\": \"JWT\",\n        \"credential\": {\n            \"@context\": [\n                \"https://www.w3.org/2018/credentials/v1\",\n                \"https://w3id.org/catenax/credentials/v1.0.0\"\n            ],\n            \"id\": \"1f36af58-0fc0-4b24-9b1c-e37d59668089\",\n            \"type\": [\n                \"VerifiableCredential\",\n                \"DataExchangeGovernanceCredential\"\n            ],\n            \"issuer\": \"did:web:dataspace-issuer\",\n            \"issuanceDate\": \"2021-06-16T18:56:59Z\",\n            \"expirationDate\": \"2032-06-16T18:56:59Z\",\n            \"credentialSubject\": {\n                \"id\": \"{{PARTICIPANT_DID}}\",\n                \"holderIdentifier\": \"{{BPN}}\",\n                \"contractTemplate\": \"https://public.catena-x.org/contracts/DataExchangeGovernance.v1.pdf\",\n                \"contractVersion\": \"1.0.0\"\n            }\n        },\n        \"rawVc\": \"{{FRAMEWORK_CREDENTIAL}}\"\n    }\n}",
+							"raw": "{\n    \"id\": \"deg-credential\",\n    \"participantContextId\": \"{{PARTICIPANT_CONTEXT_ID}}\",\n    \"issuancePolicy\": null,\n    \"reissuancePolicy\": null,\n    \"verifiableCredentialContainer\": {\n        \"format\": \"JWT\",\n        \"credential\": {\n            \"@context\": [\n                \"https://www.w3.org/2018/credentials/v1\",\n                \"https://w3id.org/catenax/credentials/v1.0.0\"\n            ],\n            \"id\": \"1f36af58-0fc0-4b24-9b1c-e37d59668089\",\n            \"type\": [\n                \"VerifiableCredential\",\n                \"DataExchangeGovernanceCredential\"\n            ],\n            \"issuer\": \"did:web:dataspace-issuer\",\n            \"issuanceDate\": \"2021-06-16T18:56:59Z\",\n            \"expirationDate\": \"2032-06-16T18:56:59Z\",\n            \"credentialSubject\": {\n                \"id\": \"{{PARTICIPANT_DID}}\",\n                \"holderIdentifier\": \"{{BPN}}\",\n                \"contractTemplate\": \"https://public.catena-x.org/contracts/DataExchangeGovernance.v1.pdf\",\n                \"contractVersion\": \"1.0.0\"\n            }\n        },\n        \"rawVc\": \"{{FRAMEWORK_CREDENTIAL}}\"\n    }\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/mxd/variables.tf
+++ b/mxd/variables.tf
@@ -52,3 +52,9 @@ variable "trudy-azure-key-sas" {
 variable "trudy-ingress-host" {
   default = "localhost"
 }
+
+variable "useSVE" {
+  type        = bool
+  description = "If true, the -XX:UseSVE=0 switch (Scalable Vector Extensions) will be added to the JAVA_TOOL_OPTIONS. Can help on macOs on Apple Silicon processors"
+  default     = false
+}


### PR DESCRIPTION
- **feat: upgrade to latest IdentityHub**
- **updated postman collection**

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
This PR updates the IdentityHub dependencies and its distribution to the latest version of the upstream project.

Please note that __only the IdentityHub dependencies__ got updated, because the other runtimes still use or depend on tractus-x edc modules, which are still on an older version.

those dependencies now have the postfix `-ih` in `libs.versions.toml`

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
