### PR TITLE
feat: Add a stale-bot to check Issues and PRs

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,110 @@
+#################################################################################
+#  Copyright (c) 2025 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+#  Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+#  See the NOTICE file(s) distributed with this work for additional
+#  information regarding copyright ownership.
+#
+#  This program and the accompanying materials are made available under the
+#  terms of the Apache License, Version 2.0 which is available at
+#  https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#  License for the specific language governing permissions and limitations
+#  under the License.
+#
+#  SPDX-License-Identifier: Apache-2.0
+#################################################################################
+
+
+---
+
+name: Close Inactive Issues
+
+on:
+  schedule:
+    - cron: "30 1 * * *" # once a day (1:30 UTC)
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  close-issues-in-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 32
+          days-before-issue-close: 14
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 4 weeks with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          remove-issue-stale-when-updated: true
+          only-labels: 'triage'
+          repo-token: ${{ github.token }}
+
+  close-issues-with-assignee:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 32
+          days-before-issue-close: 7
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 4 weeks with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          remove-issue-stale-when-updated: true
+          exempt-issue-labels: bug # ignore issues labelled as bug
+          repo-token: ${{ github.token }}
+
+  close-issues-without-assignee:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          days-before-pr-stale: -1 # ignore PRs (overwrite default days-before-stale)
+          days-before-pr-close: -1 # ignore PRs (overwrite default days-before-close)
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 2 weeks with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 7 days since being marked as stale."
+          close-issue-reason: 'not_planned'
+          remove-issue-stale-when-updated: true
+          exempt-all-issue-assignees: true # issues with assignees will be ignored
+          exempt-issue-labels: bug,triage # ignore issues labelled as bug or triage
+          repo-token: ${{ github.token }}
+
+  close-inactive-pull-requests:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          operations-per-run: 1000
+          days-before-issue-stale: -1 # ignore issues (overwrite default days-before-stale)
+          days-before-issue-close: -1 # ignore issues (overwrite default days-before-close)
+          days-before-pr-stale: 7
+          days-before-pr-close: 7
+          stale-pr-label: "stale"
+          stale-pr-message: "This pull request is stale because it has been open for 7 days with no activity."
+          close-pr-message: "This pull request was closed because it has been inactive for 7 days since being marked as stale."
+          remove-pr-stale-when-updated: true
+          repo-token: ${{ github.token }}


### PR DESCRIPTION
### WHAT

Adds a stale bot to this repo that enables marking Issues and PR's after a pre-determined period of time. Once an additional period of time passes, the Issue or PR is closed.

### WHY

To avoid having unattended, i.e. that are not being actively worked on, issues or pr's for a long period of time. 

### FURTHER NOTES

The implementation and, specially, the timelines defined for each action are in accordance with the already existing in [TractusX-EDC](https://github.com/eclipse-tractusx/tractusx-edc/blob/main/.github/workflows/stale-bot.yml) repository. Implementing this approach aimed at keep consistency in TX and the timeframes stated are reasonable.
Timelines are:
| Type | Days Before marking as Stale | Days Before closing |
| :---         |     :---:      |          :---: |
| Issue in triage   | 32    | 14    |
| Issue with assignee     | 32       | 7     |
| Issue without assignee     | 14       | 7     |
| Inactive Pull Reques     | 7       | 7     |

Closes #https://github.com/eclipse-tractusx/tutorial-resources/issues/513