### PR TITLE
fix: replace deprecated `mc config` command with `mc alias set` (Fixes #592)

### DIFF
--- a/mxd/modules/minio/s3bucket_job.tf
+++ b/mxd/modules/minio/s3bucket_job.tf
@@ -36,8 +36,7 @@ resource "kubernetes_job" "create_minio_bucket" {
           name    = "minio-client"
           image   = "minio/mc"
           command = ["/bin/sh", "-c"]
-          args    = ["mc config host add minio http://${local.minio-url} ${var.minio-username} ${var.minio-password} && mc mb --ignore-existing minio/${local.bucket-name}"]
-        }
+          args    = ["mc alias set minio http://${local.minio-url} ${var.minio-username} ${var.minio-password} && mc mb --ignore-existing minio/${local.bucket-name}"]
         restart_policy = "OnFailure"
       }
     }
@@ -65,7 +64,7 @@ resource "kubernetes_job" "minio-upload-document" {
           name    = "mc"
           image   = "minio/mc"
           command = ["/bin/sh", "-c"]
-          args    = ["mc config host add minio http://${local.minio-url} ${var.minio-username} ${var.minio-password} && mc cp /opt/config/${local.file-name} minio/${local.bucket-name}/${var.humanReadableName}-${local.file-name}"]
+          args    = ["mc alias set minio http://${local.minio-url} ${var.minio-username} ${var.minio-password} && mc cp /opt/config/${local.file-name} minio/${local.bucket-name}/${var.humanReadableName}-${local.file-name}"]
           volume_mount {
             name       = "${var.humanReadableName}-minio-document"
             mount_path = "/opt/config"


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

This PR replaces the deprecated `mc config host add` command with the new `mc alias set` command in two Kubernetes Job definitions.

MinIO has removed support for `mc config` in its latest release (2025-05-21T01-59-54Z), which caused Pod/Job failures when running `terraform apply`.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #592

Reference:
- https://github.com/minio/mc/releases/tag/RELEASE.2025-05-21T01-59-54Z
- https://min.io/docs/minio/linux/reference/minio-mc/mc-alias-set.html

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
