### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/publish-playground.yaml
+++ b/.github/workflows/publish-playground.yaml
@@ -35,9 +35,9 @@ jobs:
       contents: write
       pages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: 18
       - name: npm ci, build and test
@@ -46,7 +46,7 @@ jobs:
           npm run build -- --base-href=/tutorial-resources/policy-playground/
 
       - name: deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./edc-policy-playground/dist

--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -40,13 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: 0  # Ensure full clone for pull request workflows
 
       - name: TruffleHog OSS
         id: trufflehog
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@30d5bb91af1a771378349dbbb0c82129392acf70 # v3.95.6
         continue-on-error: true
         with:
           path: ./  # Scan the entire repository

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -39,7 +39,7 @@ jobs:
   verify-license-headers:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
       - name: "Check for files without a license header"
         run: |-
           # checks all java, yaml, kts and sql files for an Apache 2.0 license header
@@ -54,10 +54,10 @@ jobs:
   validate-terraform-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
       - name: "Setup Terraform"
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
 
       - name: "Validate Terraform format"
         working-directory: mxd


### PR DESCRIPTION
### Description

This PR pins GitHub Actions to immutable SHAs to improve supply chain security.

### Changes

- `actions/checkout` pinned to `v4.2.1`
- `actions/setup-node` pinned to `v4.1.0`
- `peaceiris/actions-gh-pages` pinned to `v4.0.0`
- `hashicorp/setup-terraform` pinned to `v3.1.2`
- `trufflesecurity/trufflehog` pinned to `v3.95.6`

### Impact

- Ensures CI/CD pipelines use verified and immutable versions of actions.
- Prevents potential supply chain attacks from mutable tags.